### PR TITLE
[공통] fix#27 브랜치 이름에 이슈 번호가 없을 때 커밋 메시지에 브랜치 이름이 추가되는 문제

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -8,11 +8,16 @@ if [[ $(head -1 "$COMMIT_MESSAGE_FILE_PATH") == '' ]]; then
   exit 0  
 fi
 
-ISSUE_NUMBER=$(git branch | grep '\*' | sed 's/* //' | sed 's/^.*\(#[0-9]*\)/\1/')
+ISSUE_NUMBER=$(git branch | grep '\*' | sed 's/* //' | sed 's/^.*\(#[0-9][0-9]*\).*$/\1/')
 
-# 커밋 메시지에 이슈 넘버가 없을 때만 이슈 넘버를 추가한다.
-if [[ "$MESSAGE" =~ \["$ISSUE_NUMBER"\] ]]; then
+# 이슈 넘버가 없으면 종료한다.
+if ! [[ ${ISSUE_NUMBER} =~ ^#[0-9][0-9]*$ ]]; then
   exit 0
 fi
 
-printf "%s\n\n[%s]" "$MESSAGE" "$ISSUE_NUMBER" > "$COMMIT_MESSAGE_FILE_PATH"
+# 커밋 메시지에 이슈 넘버가 없을 때만 이슈 넘버를 추가한다.
+if [[ ${MESSAGE} =~ \[${ISSUE_NUMBER}\] ]]; then
+  exit 0
+fi
+
+printf "%s\n\n[%s]" "${MESSAGE}" "${ISSUE_NUMBER}" > ${COMMIT_MESSAGE_FILE_PATH}


### PR DESCRIPTION
close #27 

## ✅ 작업 내용
- commit msg 훅에서 브랜치 이름에 이슈 번호가 없을 때 커밋 메시지에 브랜치 이름이 추가되는 문제 해결

## 📌 이슈 사항

## 🟢 완료 조건
- 브랜치 이름에 이슈 번호가 없으면, 커밋 메시지에 브랜치 이름이 추가되지 않는다.

## ✍ 궁금한 점
- 버그 수정 TASK인데 "개발 환경을 세팅한다 에픽 > 공통 개발 환경 세팅 스토리" 에 포함시켰습니다. 괜찮은가요.?
- 제 환경에서만 잘 동작할 수도 있어서 한 번 테스트 해주실 수 있을까요?