### PR TITLE
[FE] config#47 ESLint sort-imports, import/order 규칙 설정 및 적용

### DIFF
--- a/.yarn/sdks/eslint/bin/eslint.js
+++ b/.yarn/sdks/eslint/bin/eslint.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire} = require(`module`);
+const {resolve} = require(`path`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absRequire = createRequire(absPnpApiPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require eslint/bin/eslint.js
+    require(absPnpApiPath).setup();
+  }
+}
+
+// Defer to the real eslint/bin/eslint.js your application uses
+module.exports = absRequire(`eslint/bin/eslint.js`);

--- a/.yarn/sdks/eslint/lib/api.js
+++ b/.yarn/sdks/eslint/lib/api.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire} = require(`module`);
+const {resolve} = require(`path`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absRequire = createRequire(absPnpApiPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require eslint
+    require(absPnpApiPath).setup();
+  }
+}
+
+// Defer to the real eslint your application uses
+module.exports = absRequire(`eslint`);

--- a/.yarn/sdks/eslint/lib/unsupported-api.js
+++ b/.yarn/sdks/eslint/lib/unsupported-api.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire} = require(`module`);
+const {resolve} = require(`path`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absRequire = createRequire(absPnpApiPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require eslint/use-at-your-own-risk
+    require(absPnpApiPath).setup();
+  }
+}
+
+// Defer to the real eslint/use-at-your-own-risk your application uses
+module.exports = absRequire(`eslint/use-at-your-own-risk`);

--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "eslint",
+  "version": "8.53.0-sdk",
+  "main": "./lib/api.js",
+  "type": "commonjs",
+  "bin": {
+    "eslint": "./bin/eslint.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./lib/api.js",
+    "./use-at-your-own-risk": "./lib/unsupported-api.js"
+  }
+}

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -5,10 +5,36 @@
     "airbnb-typescript",
     "next/core-web-vitals",
     "plugin:storybook/recommended",
-    "prettier"
+    "prettier",
+    "plugin:import/recommended",
+    "plugin:import/typescript"
   ],
+  "rules": {
+    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        },
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ]
+      }
+    ]
+  },
+  "settings": {
+    "import/external-module-folders": [".yarn"]
+  },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-   "project": "./tsconfig.json"
+    "project": "./tsconfig.json"
   }
 }

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -28,7 +28,9 @@
           "index"
         ]
       }
-    ]
+    ],
+    "react/require-default-props": "off",
+    "@typescript-eslint/no-use-before-define": "off"
   },
   "settings": {
     "import/external-module-folders": [".yarn"]


### PR DESCRIPTION
close #47 

## ✅ 작업 내용
- ESLint sort-imports, import/order 규칙 설정 및 적용
  - sort-imports
    - 대소문자 구분 없이 정렬 O
    - import 문 정렬 무시 (import/order 규칙과 충돌해서 무시로 변경)
    - 멤버 정렬 O
      - ex. `import { c, b, a } from "~"` > `import { a, b, c } from "~"`
    - 멤버 갯수(?)에 따라 none, all, multiple, single 순으로 정렬 (자세한 설명은 [여기](https://eslint.org/docs/latest/rules/sort-imports#options)에)
    - 그룹 내에서 개행 불가능
  - import/order
    - builtin, external, internal, parent, sibling, index 그룹 모듈 순으로 정렬
    - 모듈 그룹간 개행을 항상 추가
  - .yarn 경로 내 모듈을 external로 설정   
- ESLint require-default-props, no-use-before-define 규칙 off
- ESLint vscode sdks 설치

## 📌 이슈 사항
- sort-imports랑 import/order 규칙이 충돌할 때가 있다는데, 현재 import 문이 많지 않아서 충돌하는 규칙을 모르겠습니다.. 나중에 충돌 발생하면 규칙 고쳐야 할 수도 있습니다!
- `import from "~"`와 같은 [side effect import문](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#forms_of_import_declarations)은 **부수 효과**가 있을 수 있기 때문에 **import 순서가 중요해** ESLint 에서 검사 및 수정하지 않는다고 합니다. (?)

## 🟢 완료 조건
- import 순서가 정렬된다.
- 테스트용

|적용 전|적용 후|
|-|-|
|<img width="460" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/4c31dc05-a0e9-4e03-85e4-4ba3d3eaa5c4">|<img width="408" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/93cd550b-6e12-4bce-b5eb-bd7fecbc7a4e">|

## ✍ 궁금한 점
- 정렬 규칙 수정할 곳 있으면 알려주세요!





