### PR TITLE
[FE] feat#43 Button 컴포넌트

### DIFF
--- a/packages/frontend/src/components/common/Button/Button.css.ts
+++ b/packages/frontend/src/components/common/Button/Button.css.ts
@@ -6,7 +6,7 @@ import typography from "../../../styles/typography";
 export const widthFull = style({ width: "100%" });
 
 export const buttonBaseStyle = style([
-  typography.$semantic.title2Regular,
+  typography.$semantic.title3Regular,
   {
     height: 48,
     border: "1px solid transparent",
@@ -14,16 +14,16 @@ export const buttonBaseStyle = style([
     padding: "12px 30px",
 
     ":disabled": {
-      borderColor: color.$scale.grey200,
-      color: color.$scale.grey500,
-      backgroundColor: color.$scale.grey200,
+      borderColor: color.$semantic.bgDisabled,
+      color: color.$semantic.textDisabled,
+      backgroundColor: color.$semantic.bgDisabled,
     },
   },
 ]);
 
 export const buttonVariantStyle = styleVariants({
   primaryFill: {
-    color: color.$scale.grey00,
+    color: color.$semantic.textWhite,
     backgroundColor: color.$semantic.primary,
 
     selectors: {
@@ -34,7 +34,7 @@ export const buttonVariantStyle = styleVariants({
   },
 
   secondaryFill: {
-    color: color.$scale.grey00,
+    color: color.$semantic.textWhite,
     backgroundColor: color.$semantic.secondary,
 
     selectors: {
@@ -47,7 +47,7 @@ export const buttonVariantStyle = styleVariants({
   primaryLine: {
     border: `1px solid ${color.$semantic.primary}`,
     color: color.$semantic.primary,
-    backgroundColor: color.$scale.grey00,
+    backgroundColor: color.$semantic.bgWhite,
 
     selectors: {
       "&:hover:not(:disabled)": {
@@ -59,7 +59,7 @@ export const buttonVariantStyle = styleVariants({
   secondaryLine: {
     border: `1px solid ${color.$semantic.secondary}`,
     color: color.$semantic.secondary,
-    backgroundColor: color.$scale.grey00,
+    backgroundColor: color.$semantic.bgWhite,
 
     selectors: {
       "&:hover:not(:disabled)": {

--- a/packages/frontend/src/components/common/Button/Button.css.ts
+++ b/packages/frontend/src/components/common/Button/Button.css.ts
@@ -1,0 +1,95 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+
+import color from "../../../styles/color";
+import typography from "../../../styles/typography";
+
+export const widthFull = style({ width: "100%" });
+
+export const buttonBaseStyle = style([
+  typography.$semantic.title2Regular,
+  {
+    height: 48,
+    border: "1px solid transparent",
+    borderRadius: 8,
+    padding: "12px 30px",
+
+    ":disabled": {
+      borderColor: color.$scale.grey200,
+      color: color.$scale.grey500,
+      backgroundColor: color.$scale.grey200,
+    },
+  },
+]);
+
+export const buttonVariantStyle = styleVariants({
+  primaryFill: {
+    color: color.$scale.grey00,
+    backgroundColor: color.$semantic.primary,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        backgroundColor: color.$semantic.primaryHover,
+      },
+    },
+  },
+
+  secondaryFill: {
+    color: color.$scale.grey00,
+    backgroundColor: color.$semantic.secondary,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        backgroundColor: color.$semantic.secondaryHover,
+      },
+    },
+  },
+
+  primaryLine: {
+    border: `1px solid ${color.$semantic.primary}`,
+    color: color.$semantic.primary,
+    backgroundColor: color.$scale.grey00,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        backgroundColor: color.$semantic.primaryLow,
+      },
+    },
+  },
+
+  secondaryLine: {
+    border: `1px solid ${color.$semantic.secondary}`,
+    color: color.$semantic.secondary,
+    backgroundColor: color.$scale.grey00,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        color: color.$semantic.secondary,
+        backgroundColor: color.$semantic.secondaryLow,
+      },
+    },
+  },
+
+  primaryLow: {
+    color: color.$semantic.primary,
+    backgroundColor: color.$semantic.primaryLow,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        backgroundColor: color.$semantic.primaryLowHover,
+      },
+    },
+  },
+
+  secondaryLow: {
+    color: color.$semantic.secondary,
+    backgroundColor: color.$semantic.secondaryLow,
+
+    selectors: {
+      "&:hover:not(:disabled)": {
+        backgroundColor: color.$semantic.secondaryLowHover,
+      },
+    },
+  },
+});
+
+export type ButtonVariants = keyof typeof buttonVariantStyle;

--- a/packages/frontend/src/components/common/Button/Button.tsx
+++ b/packages/frontend/src/components/common/Button/Button.tsx
@@ -1,5 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
+import classnames from "../../../utils/classnames";
+
 import {
   type ButtonVariants,
   buttonBaseStyle,
@@ -25,26 +27,20 @@ export function Button({
   disabled = false,
   onClick,
 }: ButtonProps) {
+  const buttonStyle = classnames(
+    buttonBaseStyle,
+    buttonVariantStyle[variant],
+    full ? widthFull : ""
+  );
+
   return (
     <button
       type={type === "button" ? "button" : "submit"}
-      className={getButtonStyle({ full, variant })}
+      className={buttonStyle}
       onClick={onClick}
       disabled={disabled}
     >
       {children}
     </button>
   );
-}
-
-function getButtonStyle({
-  full,
-  variant,
-}: {
-  full: boolean;
-  variant: ButtonVariants;
-}) {
-  return [buttonBaseStyle, buttonVariantStyle[variant], full ? widthFull : ""]
-    .join(" ")
-    .trim();
 }

--- a/packages/frontend/src/components/common/Button/Button.tsx
+++ b/packages/frontend/src/components/common/Button/Button.tsx
@@ -1,0 +1,50 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+import {
+  type ButtonVariants,
+  buttonBaseStyle,
+  buttonVariantStyle,
+  widthFull,
+} from "./Button.css";
+
+export interface ButtonProps
+  extends Pick<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    "type" | "disabled" | "onClick"
+  > {
+  full?: boolean;
+  variant: ButtonVariants;
+  children: ReactNode;
+}
+
+export function Button({
+  full = false,
+  variant,
+  children,
+  type = "button",
+  disabled = false,
+  onClick,
+}: ButtonProps) {
+  return (
+    <button
+      type={type === "button" ? "button" : "submit"}
+      className={getButtonStyle({ full, variant })}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+
+function getButtonStyle({
+  full,
+  variant,
+}: {
+  full: boolean;
+  variant: ButtonVariants;
+}) {
+  return [buttonBaseStyle, buttonVariantStyle[variant], full ? widthFull : ""]
+    .join(" ")
+    .trim();
+}

--- a/packages/frontend/src/components/common/index.ts
+++ b/packages/frontend/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./Button/Button";

--- a/packages/frontend/src/styles/color.ts
+++ b/packages/frontend/src/styles/color.ts
@@ -35,6 +35,10 @@ const $scale = {
 };
 
 const $semantic = {
+  textWhite: "var(--mm-semantic-color-text-white-default)",
+  bgWhite: "var(--mm-semantic-color-bg-white-default)",
+  textDisabled: "var(--mm-semantic-color-text-disabled)",
+  bgDisabled: "var(--mm-semantic-color-bg-disabled)",
   primary: "var(--mm-semantic-color-primary)",
   primaryHover: "var(--mm-semantic-color-primary-hover)",
   primaryLow: "var(--mm-semantic-color-primary-low)",

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -2,6 +2,10 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
 @import url("http://fonts.googleapis.com/earlyaccess/notosanskr.css");
 
+* {
+  box-sizing: border-box;
+}
+
 :root[data-theme] {
   --mm-static-color-white: #ffffff;
   --mm-static-color-grey-200: #eaebee;

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -3,6 +3,9 @@
 @import url("http://fonts.googleapis.com/earlyaccess/notosanskr.css");
 
 :root[data-theme] {
+  --mm-static-color-white: #ffffff;
+  --mm-static-color-grey-200: #eaebee;
+  --mm-static-color-grey-500: #adb1ba;
   --mm-static-color-blue-50: #e8f3ff;
   --mm-static-color-blue-700: #1b64da;
   --mm-static-color-brown-50: #f4efee;
@@ -25,6 +28,10 @@
   --mm-static-color-teal-700: #0c8585;
   --mm-static-color-yellow-50: #fff9e7;
   --mm-static-color-yellow-700: #faa131;
+  --mm-semantic-color-text-white-default: var(--mm-static-color-white);
+  --mm-semantic-color-bg-white-default: var(--mm-static-color-white);
+  --mm-semantic-color-text-disabled: var(--mm-static-color-grey-500);
+  --mm-semantic-color-bg-disabled: var(--mm-static-color-grey-200);
   --mm-semantic-color-badge-blue-bg: var(--mm-static-color-blue-50);
   --mm-semantic-color-badge-blue: var(--mm-static-color-blue-700);
   --mm-semantic-color-badge-green-bg: var(--mm-static-color-green-50);

--- a/packages/frontend/src/utils/__tests__/classnames.spec.ts
+++ b/packages/frontend/src/utils/__tests__/classnames.spec.ts
@@ -1,0 +1,13 @@
+import classnames from "../classnames";
+
+describe("classnames", () => {
+  test.each([
+    { expected: "", input: [""] },
+    { expected: "", input: [" "] },
+    { expected: "foo bar", input: ["foo", "bar"] },
+    { expected: "foo bar", input: ["foo", "bar", "", " "] },
+    { expected: "foo bar a", input: [" foo ", " bar ", "", " ", " a "] },
+  ])(`classnames(...$input)는 $expected를 반환한다`, ({ input, expected }) => {
+    expect(classnames(...input)).toBe(expected);
+  });
+});

--- a/packages/frontend/src/utils/__tests__/typeGuard.spec.ts
+++ b/packages/frontend/src/utils/__tests__/typeGuard.spec.ts
@@ -1,0 +1,19 @@
+import { isString } from "../typeGuard";
+
+describe("isString", () => {
+  test.each([
+    ["", true],
+    [" ", true],
+    ["c", true],
+    ["string", true],
+    [String(10), true],
+    [{}, false],
+    [() => {}, false],
+    [function a() {}, false],
+    [NaN, false],
+    [undefined, false],
+    [null, false],
+  ])(`isString(%p)는 %p를 반환한다`, (value, expected) => {
+    expect(isString(value)).toBe(expected);
+  });
+});

--- a/packages/frontend/src/utils/classnames.ts
+++ b/packages/frontend/src/utils/classnames.ts
@@ -1,0 +1,11 @@
+export default function classnames(...args: string[]) {
+  return args
+    .map((value) => value.trim())
+    .filter(isTruthy)
+    .join(" ")
+    .trim();
+}
+
+function isTruthy(value: unknown) {
+  return !!value;
+}

--- a/packages/frontend/src/utils/typeGuard.ts
+++ b/packages/frontend/src/utils/typeGuard.ts
@@ -1,0 +1,3 @@
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}


### PR DESCRIPTION
close #43

## ✅ 작업 내용
- Button 컴포넌트 구현

## 📸 스크린샷
![Button](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/e20395c6-9f00-4e39-a6d0-f56f0e292dfc)


## 📌 이슈 사항
- Storybook + vanilla extract 에러는 나중에 해결하겠습니다..

## 🟢 완료 조건
- vanilla extract를 사용해서 색상별로 variant를 선언한다.
- disabled 된 Button은 hover해도 스타일 변화가 없다.

## ✍ 궁금한 점
- vanilla extract는 클래스 이름으로 스타일링하다보니 클래스 이름을 쉽게 조합하는 [classnames 패키지](https://github.com/JedWatson/classnames)가 생각났습니다! 그런데 아직 많은 기능이 필요한 것 같지는 않아서 작은 유틸 함수 하나 만들어봤습니다. 패키지 설치보다는 기능 하나씩 추가하는 것도 괜찮은 것 같은데 어떻게 생각하시나요?
- 스타일링 잘못된 곳이 있다면 알려주세요!
- 버튼에 `width` 값이 없어서 `border` 유무에 따라 버튼 `width` 가 달라집니다..! 그래서 `border: "1px solid transparent",`으로 동일한 `width` 가 되도록 해봤는데 괜찮은가요?

cf. [테스트용 코드](https://www.notion.so/Button-bcf4a703907d4c1780a360f3fe890bb7)