### PR TITLE
[FE] feat#42 Badge 컴포넌트

### DIFF
--- a/packages/frontend/src/components/common/Badge/Badge.css.ts
+++ b/packages/frontend/src/components/common/Badge/Badge.css.ts
@@ -1,0 +1,48 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+
+import color from "../../../styles/color";
+import typography from "../../../styles/typography";
+
+export const container = style({
+  display: "flex",
+  gap: 10,
+});
+
+export const badgeBaseStyle = style([
+  typography.$semantic.caption2Regular,
+  {
+    color: color.$semantic.textWhite,
+    height: 22,
+    padding: "3px 7px",
+    borderRadius: 5,
+  },
+]);
+
+export const badgeVariants = styleVariants({
+  orange: {
+    color: color.$semantic.badgeOrange,
+    backgroundColor: color.$semantic.badgeOrangeBg,
+  },
+  yellow: {
+    color: color.$semantic.badgeYellow,
+    backgroundColor: color.$semantic.badgeYellowBg,
+  },
+  green: {
+    color: color.$semantic.badgeGreen,
+    backgroundColor: color.$semantic.badgeGreenBg,
+  },
+  teal: {
+    color: color.$semantic.badgeTeal,
+    backgroundColor: color.$semantic.badgeTealBg,
+  },
+  blue: {
+    color: color.$semantic.badgeBlue,
+    backgroundColor: color.$semantic.badgeBlueBg,
+  },
+  purple: {
+    color: color.$semantic.badgePurple,
+    backgroundColor: color.$semantic.badgePurpleBg,
+  },
+});
+
+export type BadgeVariant = keyof typeof badgeVariants;

--- a/packages/frontend/src/components/common/Badge/Badge.css.ts
+++ b/packages/frontend/src/components/common/Badge/Badge.css.ts
@@ -11,7 +11,6 @@ export const container = style({
 export const badgeBaseStyle = style([
   typography.$semantic.caption2Regular,
   {
-    color: color.$semantic.textWhite,
     height: 22,
     padding: "3px 7px",
     borderRadius: 5,

--- a/packages/frontend/src/components/common/Badge/Badge.tsx
+++ b/packages/frontend/src/components/common/Badge/Badge.tsx
@@ -1,10 +1,10 @@
-import { HTMLAttributes, ReactNode } from "react";
+import { ReactNode } from "react";
 
 import classnames from "../../../utils/classnames";
 
 import * as styles from "./Badge.css";
 
-export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+export interface BadgeProps {
   variant: styles.BadgeVariant;
   label: ReactNode;
 }

--- a/packages/frontend/src/components/common/Badge/Badge.tsx
+++ b/packages/frontend/src/components/common/Badge/Badge.tsx
@@ -1,0 +1,18 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+import classnames from "../../../utils/classnames";
+
+import * as styles from "./Badge.css";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant: styles.BadgeVariant;
+  label: ReactNode;
+}
+
+export function Badge({ variant, label }: BadgeProps) {
+  const badgeStyle = classnames(
+    styles.badgeBaseStyle,
+    styles.badgeVariants[variant],
+  );
+  return <span className={badgeStyle}>{label}</span>;
+}

--- a/packages/frontend/src/components/common/Badge/BadgeGroup.tsx
+++ b/packages/frontend/src/components/common/Badge/BadgeGroup.tsx
@@ -1,0 +1,29 @@
+import { Badge } from "./Badge";
+import * as styles from "./Badge.css";
+
+const variants: styles.BadgeVariant[] = [
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "teal",
+  "purple",
+];
+
+export interface BadgeGroupProps {
+  items: { label: string }[];
+}
+
+export function BadgeGroup({ items }: BadgeGroupProps) {
+  return (
+    <div className={styles.container}>
+      {items.map((item, index) => (
+        <Badge
+          variant={variants[index % variants.length]}
+          label={item.label}
+          key={item.label}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/common/Badge/BadgeGroup.tsx
+++ b/packages/frontend/src/components/common/Badge/BadgeGroup.tsx
@@ -1,15 +1,9 @@
+import { objectKeys } from "../../../utils/types";
+
 import { Badge } from "./Badge";
 import * as styles from "./Badge.css";
 
-const variants: styles.BadgeVariant[] = [
-  "orange",
-  "yellow",
-  "green",
-  "blue",
-  "teal",
-  "purple",
-];
-
+const variants = objectKeys(styles.badgeVariants);
 export interface BadgeGroupProps {
   items: { label: string }[];
 }

--- a/packages/frontend/src/components/common/Badge/index.ts
+++ b/packages/frontend/src/components/common/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from "./Badge";
+export { BadgeGroup } from "./BadgeGroup";

--- a/packages/frontend/src/components/common/Button/Button.tsx
+++ b/packages/frontend/src/components/common/Button/Button.tsx
@@ -2,12 +2,7 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 import classnames from "../../../utils/classnames";
 
-import {
-  type ButtonVariants,
-  buttonBaseStyle,
-  buttonVariantStyle,
-  widthFull,
-} from "./Button.css";
+import * as styles from "./Button.css";
 
 export interface ButtonProps
   extends Pick<
@@ -15,7 +10,7 @@ export interface ButtonProps
     "type" | "disabled" | "onClick"
   > {
   full?: boolean;
-  variant: ButtonVariants;
+  variant: styles.ButtonVariants;
   children: ReactNode;
 }
 
@@ -28,9 +23,9 @@ export function Button({
   onClick,
 }: ButtonProps) {
   const buttonStyle = classnames(
-    buttonBaseStyle,
-    buttonVariantStyle[variant],
-    full ? widthFull : ""
+    styles.buttonBaseStyle,
+    styles.buttonVariantStyle[variant],
+    full ? styles.widthFull : "",
   );
 
   return (

--- a/packages/frontend/src/components/common/Button/index.ts
+++ b/packages/frontend/src/components/common/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./Button";

--- a/packages/frontend/src/components/common/index.ts
+++ b/packages/frontend/src/components/common/index.ts
@@ -1,2 +1,2 @@
-export { Button } from "./Button/Button";
+export { Button } from "./Button";
 export { Badge, BadgeGroup } from "./Badge";

--- a/packages/frontend/src/components/common/index.ts
+++ b/packages/frontend/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export { Button } from "./Button/Button";
+export { Badge, BadgeGroup } from "./Badge";

--- a/packages/frontend/src/utils/types.ts
+++ b/packages/frontend/src/utils/types.ts
@@ -1,0 +1,10 @@
+export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<
+  keyof T,
+  symbol
+>}`;
+
+export function objectKeys<Type extends Record<PropertyKey, unknown>>(
+  obj: Type,
+): Array<ObjectKeys<Type>> {
+  return Object.keys(obj) as Array<ObjectKeys<Type>>;
+}

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -17,11 +17,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    },
     "forceConsistentCasingInFileNames": true
   },
   "include": [


### PR DESCRIPTION
close #42 

## ✅ 작업 내용
- Badge 컴포넌트 구현
- BadgeGroup 컴포넌트 구현
- 절대경로 해제
- 컴포넌트별 index.ts 파일로 컴포넌트 export 하도록 변경
- Button 컴포넌트에 style import에 styles 프리픽스 적용

## 📸 스크린샷(FE만)
<img width="520" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/ce849378-75bf-4586-8686-2c72301f7773">

## 📌 이슈 사항
- 없습니다!

## 🟢 완료 조건
- BadgeGroup으로 핵심 명령어 목록을 보여줄 수 있다.

## ✍ 궁금한 점
- BadgeGroup에서 variant list(색상 리스트)를 array로 관리하는데 더 좋은 방법이 있을까 싶어요!

cf. [테스트 코드](https://bow-snail-89d.notion.site/Badge-BadgeGroup-7c9534ec6476434290e3ae63484490a9?pvs=4)