### PR TITLE
[FE] feat#63 Footer 컴포넌트

### DIFF
--- a/packages/frontend/src/design-system/components/common/Footer/Footer.css.ts
+++ b/packages/frontend/src/design-system/components/common/Footer/Footer.css.ts
@@ -1,0 +1,54 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../../tokens/color";
+import typography from "../../../tokens/typography";
+import { flex } from "../../../tokens/utils.css";
+
+export const container = style({
+  backgroundColor: color.$scale.grey200,
+});
+
+export const content = style([
+  flex,
+  {
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    marginTop: 13,
+  },
+]);
+
+export const teamName = style([
+  typography.$semantic.title2Bold,
+  {
+    color: color.$scale.grey800,
+  },
+]);
+
+export const teamInfo = style([
+  typography.$semantic.caption1Regular,
+  {
+    flex: 1,
+    color: color.$scale.grey600,
+  },
+]);
+
+export const contact = style({
+  color: color.$scale.grey600,
+});
+
+export const hr = style({
+  margin: "20px 0",
+  border: "none",
+  borderTop: `1px solid ${color.$semantic.border}`,
+});
+
+export const rightsContainer = style([
+  typography.$semantic.caption1Regular,
+  {
+    position: "relative",
+    textAlign: "center",
+    color: color.$scale.grey500,
+  },
+]);
+
+export const rights = style({ position: "absolute", left: 0 });

--- a/packages/frontend/src/design-system/components/common/Footer/Footer.tsx
+++ b/packages/frontend/src/design-system/components/common/Footer/Footer.tsx
@@ -1,0 +1,44 @@
+import { AiFillGithub } from "react-icons/ai";
+
+import { footer as footerLayout } from "../../../tokens/layout.css";
+
+import * as styles from "./Footer.css";
+
+export default function Footer() {
+  return (
+    <footer className={styles.container}>
+      <div className={footerLayout}>
+        <strong className={styles.teamName}>Merge Masters</strong>
+        <div className={styles.content}>
+          <div className={styles.teamInfo}>
+            <div>Team : Merge Master</div>
+            <div>
+              Contact :{" "}
+              <a
+                href="https://github.com/boostcampwm2023/web01-GitChallenge/issues"
+                target="_blank"
+                className={styles.contact}
+              >
+                Issues
+              </a>
+            </div>
+          </div>
+          <div>
+            <a
+              href="https://github.com/boostcampwm2023/web01-GitChallenge"
+              target="_blank"
+              aria-label="GitHub Repository"
+            >
+              <AiFillGithub size={36} color="black" />
+            </a>
+          </div>
+        </div>
+        <hr className={styles.hr} />
+        <div className={styles.rightsContainer}>
+          <span className={styles.rights}>© 2023 All rights reserved</span>
+          <span>해당 웹사이트는 Chrome에 최적화되어 있습니다.</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/packages/frontend/src/design-system/components/common/Footer/index.ts
+++ b/packages/frontend/src/design-system/components/common/Footer/index.ts
@@ -1,0 +1,3 @@
+import Footer from "./Footer";
+
+export default Footer;

--- a/packages/frontend/src/design-system/components/common/index.ts
+++ b/packages/frontend/src/design-system/components/common/index.ts
@@ -2,3 +2,4 @@ export { default as Button } from "./Button";
 export { Badge, BadgeGroup } from "./Badge";
 export { toast, ToastContainer } from "./Toast";
 export { Accordion, useAccordion } from "./Accordion";
+export { default as Footer } from "./Footer";


### PR DESCRIPTION
close #63

## ✅ 작업 내용
- Footer 컴포넌트 구현
- 깃허브 아이콘 클릭 시 GitChallenge 레포 페이지 연결

## 📸 스크린샷
- body 태그에 적용된 flex 없애고 테스트 했습니다!

![footer](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/1fb72004-0975-4c5d-9a72-4aba227c94a5)

## 📌 이슈 사항
- 테스트 커밋([888bec2](https://github.com/boostcampwm2023/web01-GitChallenge/pull/80/commits/888bec2ec8f52760bc5938613b07f00059e2da29)) 없애고 머지해야 합니다!

## 🟢 완료 조건
- 디자인 명세에 맞게 스타일링한다.
- 깃허브 아이콘으로 GitChallenge 레포로 이동할 수 있다.
- Contact: Issues로 MergeMasters에게 연락할 수 있다.(?)

## ✍ 궁금한 점
- Contact에 임시로 GitChallenge 레포 이슈 페이지 연결했습니다. 다른 걸로 바꿀까요?