### PR TITLE
[FE] feat#41 Modal 컴포넌트

### DIFF
--- a/packages/frontend/src/constants/index.ts
+++ b/packages/frontend/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const ESC_KEY_CODE = "Escape";

--- a/packages/frontend/src/design-system/components/common/Button/Button.css.ts
+++ b/packages/frontend/src/design-system/components/common/Button/Button.css.ts
@@ -19,7 +19,7 @@ export const buttonBase = style([
   },
 ]);
 
-export const buttonVariantStyle = styleVariants({
+export const buttonVariants = styleVariants({
   primaryFill: {
     color: color.$semantic.textWhite,
     backgroundColor: color.$semantic.primary,

--- a/packages/frontend/src/design-system/components/common/Button/Button.tsx
+++ b/packages/frontend/src/design-system/components/common/Button/Button.tsx
@@ -3,10 +3,9 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 import classnames from "../../../../utils/classnames";
 import * as utils from "../../../tokens/utils.css";
 
-import { buttonVariantStyle } from "./Button.css";
 import * as styles from "./Button.css";
 
-export type ButtonVariantType = keyof typeof buttonVariantStyle;
+export type ButtonVariantType = keyof typeof styles.buttonVariants;
 
 export interface ButtonProps
   extends Pick<
@@ -28,7 +27,7 @@ export function Button({
 }: ButtonProps) {
   const buttonStyle = classnames(
     styles.buttonBase,
-    styles.buttonVariantStyle[variant],
+    styles.buttonVariants[variant],
     full ? utils.widthFull : "",
   );
 

--- a/packages/frontend/src/design-system/components/common/IconButton/IconButton.css.ts
+++ b/packages/frontend/src/design-system/components/common/IconButton/IconButton.css.ts
@@ -1,0 +1,12 @@
+import { style } from "@vanilla-extract/css";
+
+import * as utils from "../../../tokens/utils.css";
+
+export const button = style([
+  utils.flex,
+  {
+    padding: 0,
+    backgroundColor: "transparent",
+    border: "none",
+  },
+]);

--- a/packages/frontend/src/design-system/components/common/IconButton/IconButton.tsx
+++ b/packages/frontend/src/design-system/components/common/IconButton/IconButton.tsx
@@ -5,13 +5,13 @@ import classnames from "../../../../utils/classnames";
 import * as styles from "./IconButton.css";
 
 export interface IconButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement> {
-  className: string;
+  extends Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  className?: string;
   children: ReactNode;
 }
 
 export default function IconButton({
-  className,
+  className = "",
   children,
   onClick,
 }: IconButtonProps) {

--- a/packages/frontend/src/design-system/components/common/IconButton/IconButton.tsx
+++ b/packages/frontend/src/design-system/components/common/IconButton/IconButton.tsx
@@ -1,0 +1,24 @@
+import { ButtonHTMLAttributes, ReactNode } from "react";
+
+import classnames from "../../../../utils/classnames";
+
+import * as styles from "./IconButton.css";
+
+export interface IconButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  className: string;
+  children: ReactNode;
+}
+
+export default function IconButton({
+  className,
+  children,
+  onClick,
+}: IconButtonProps) {
+  const iconButtonStyle = classnames(styles.button, className);
+  return (
+    <button type="button" className={iconButtonStyle} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/packages/frontend/src/design-system/components/common/IconButton/index.ts
+++ b/packages/frontend/src/design-system/components/common/IconButton/index.ts
@@ -1,0 +1,3 @@
+import IconButton from "./IconButton";
+
+export default IconButton;

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.css.ts
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.css.ts
@@ -8,6 +8,8 @@ export const backdrop = style([
   utils.flexCenter,
   {
     position: "fixed",
+    top: 0,
+    left: 0,
     width: "100vw",
     height: "100vh",
     backgroundColor: "rgba(0, 0, 0, 0.6)",

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.css.ts
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.css.ts
@@ -1,0 +1,40 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../../tokens/color";
+import * as utils from "../../../tokens/utils.css";
+
+export const backdrop = style([
+  utils.modalLayer,
+  utils.flexCenter,
+  {
+    position: "fixed",
+    width: "100vw",
+    height: "100vh",
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+  },
+]);
+
+export const container = style([
+  utils.boxShadow,
+  utils.flexColumn,
+  utils.flexAlignCenter,
+  {
+    width: 427,
+    borderRadius: 8,
+    padding: 27,
+    backgroundColor: color.$scale.grey00,
+  },
+]);
+
+export const buttonContainer = style({
+  width: "100%",
+  height: 40,
+  position: "relative",
+});
+
+export const close = style({
+  color: color.$scale.grey900,
+  position: "absolute",
+  right: 0,
+  fontSize: 40,
+});

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
@@ -30,14 +30,14 @@ export default function Modal({ onClose, children }: ModalProps) {
       onClick={onClose}
       role="button"
       tabIndex={0}
-      aria-hidden="true"
+      onKeyDown={onClose}
     >
       <div
         className={styles.container}
         onClick={preventBubbling}
         role="button"
         tabIndex={0}
-        aria-hidden="true"
+        onKeyDown={onClose}
       >
         <div className={styles.buttonContainer}>
           <IconButton className={styles.close} onClick={onClose}>

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { IoCloseOutline } from "react-icons/io5";
 
-import useModal from "../../../../hooks/useModal";
+import { ESC_KEY_CODE } from "../../../../constants";
 import { preventBubbling } from "../../../../utils/event";
 import IconButton from "../IconButton/IconButton";
 
@@ -13,14 +13,27 @@ export interface ModalProps {
   children: ReactNode;
 }
 
+const setScrollLock = (isLock: boolean) => {
+  document.body.style.overflow = isLock ? "hidden" : "auto";
+};
+
 export default function Modal({ onClose, children }: ModalProps) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
+    const escKeyCloseEvent = (event: KeyboardEvent) => {
+      if (event.key === ESC_KEY_CODE) {
+        onClose();
+      }
+    };
+    setScrollLock(true);
+    window.addEventListener("keydown", escKeyCloseEvent);
+    return () => {
+      window.removeEventListener("keydown", escKeyCloseEvent);
+      setScrollLock(false);
+    };
   }, []);
-
-  useModal({ onClose });
 
   if (!mounted) return null;
 

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
@@ -1,0 +1,52 @@
+import { ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { IoCloseOutline } from "react-icons/io5";
+
+import useModal from "../../../../hooks/useModal";
+import { preventBubbling } from "../../../../utils/event";
+import IconButton from "../IconButton/IconButton";
+
+import * as styles from "./Modal.css";
+
+export interface ModalProps {
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ onClose, children }: ModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useModal({ onClose });
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className={styles.backdrop}
+      onClick={onClose}
+      role="button"
+      tabIndex={0}
+      aria-hidden="true"
+    >
+      <div
+        className={styles.container}
+        onClick={preventBubbling}
+        role="button"
+        tabIndex={0}
+        aria-hidden="true"
+      >
+        <div className={styles.buttonContainer}>
+          <IconButton className={styles.close} onClick={onClose}>
+            <IoCloseOutline />
+          </IconButton>
+        </div>
+        {children}
+      </div>
+    </div>,
+    document.getElementById("modal") as HTMLElement,
+  );
+}

--- a/packages/frontend/src/design-system/components/common/Modal/index.ts
+++ b/packages/frontend/src/design-system/components/common/Modal/index.ts
@@ -1,0 +1,3 @@
+import Modal from "./Modal";
+
+export default Modal;

--- a/packages/frontend/src/design-system/components/common/index.ts
+++ b/packages/frontend/src/design-system/components/common/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from "./Button";
+export { default as Modal } from "./Modal";
 export { Badge, BadgeGroup } from "./Badge";
 export { toast, ToastContainer } from "./Toast";

--- a/packages/frontend/src/design-system/tokens/utils.css.ts
+++ b/packages/frontend/src/design-system/tokens/utils.css.ts
@@ -38,3 +38,7 @@ export const flexColumnCenter = style([
     flexDirection: "column",
   },
 ]);
+
+export const boxShadow = style({
+  boxShadow: "0 3px 10px rgba(0,0,0,0.1), 0 3px 3px rgba(0,0,0,0.05)",
+});

--- a/packages/frontend/src/hooks/useModal.ts
+++ b/packages/frontend/src/hooks/useModal.ts
@@ -1,24 +1,14 @@
-import { useEffect } from "react";
+import { useState } from "react";
 
-import { ESC_KEY_CODE } from "../constants";
-
-export default function useModal({ onClose }: { onClose: () => void }) {
-  const escKeyCloseEvent = (event: KeyboardEvent) => {
-    if (event.key === ESC_KEY_CODE) {
-      onClose();
-    }
+export default function useModal() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const closeModal = () => {
+    setModalOpen(false);
   };
 
-  useEffect(() => {
-    setScrollLock(true);
-    window.addEventListener("keydown", escKeyCloseEvent);
-    return () => {
-      window.removeEventListener("keydown", escKeyCloseEvent);
-      setScrollLock(false);
-    };
-  }, []);
-
-  const setScrollLock = (isLock: boolean) => {
-    document.body.style.overflow = isLock ? "hidden" : "auto";
+  const openModal = () => {
+    setModalOpen(true);
   };
+
+  return { modalOpen, openModal, closeModal };
 }

--- a/packages/frontend/src/hooks/useModal.ts
+++ b/packages/frontend/src/hooks/useModal.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+import { ESC_KEY_CODE } from "../constants";
+
+export default function useModal({ onClose }: { onClose: () => void }) {
+  const escKeyCloseEvent = (event: KeyboardEvent) => {
+    if (event.key === ESC_KEY_CODE) {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    setScrollLock(true);
+    window.addEventListener("keydown", escKeyCloseEvent);
+    return () => {
+      window.removeEventListener("keydown", escKeyCloseEvent);
+      setScrollLock(false);
+    };
+  }, []);
+
+  const setScrollLock = (isLock: boolean) => {
+    document.body.style.overflow = isLock ? "hidden" : "auto";
+  };
+}

--- a/packages/frontend/src/pages/_document.tsx
+++ b/packages/frontend/src/pages/_document.tsx
@@ -5,8 +5,8 @@ export default function Document() {
     <Html data-theme="light" lang="en">
       <Head />
       <body>
-        <div id="modal" />
         <Main />
+        <div id="modal" />
         <NextScript />
       </body>
     </Html>

--- a/packages/frontend/src/pages/_document.tsx
+++ b/packages/frontend/src/pages/_document.tsx
@@ -1,10 +1,11 @@
-import { Html, Head, Main, NextScript } from "next/document";
+import { Head, Html, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
     <Html data-theme="light" lang="en">
       <Head />
       <body>
+        <div id="modal" />
         <Main />
         <NextScript />
       </body>

--- a/packages/frontend/src/utils/event.ts
+++ b/packages/frontend/src/utils/event.ts
@@ -1,0 +1,5 @@
+const preventBubbling = (e: React.MouseEvent<HTMLElement>) => {
+  e.stopPropagation();
+};
+
+export { preventBubbling };

--- a/packages/frontend/src/utils/event.ts
+++ b/packages/frontend/src/utils/event.ts
@@ -1,4 +1,4 @@
-const preventBubbling = (e: React.MouseEvent<HTMLElement>) => {
+const preventBubbling = (e: React.MouseEvent<Element>) => {
   e.stopPropagation();
 };
 


### PR DESCRIPTION
close #41 

## ✅ 작업 내용
- IconButton 컴포넌트 구현
- React createPortal로 모달 컴포넌트 구현
- 백드롭 클릭 시 모달 꺼지도록 구현 + 모달 박스 클릭시 이벤트 버블링 방지로 util 함수 구현 후 적용
- esc 키 눌렀을 때 모달 꺼지도록 구현
- 모달이 켜져있을 때 스크롤 안되도록 처리

## 📸 스크린샷(FE만)
![Nov-20-2023 17-51-58](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/e33d3007-d21c-45b5-a234-20b8b7f3f841)

커서가... 보이는줄 알았는데 안보이네요...?!
위 내용 모두 테스트 완료했습니다!

## 📌 이슈 사항
### Next.js에서 createPortal 사용 시 document를 찾지 못하는 문제
마운트 되지 않았을 때 모달에서 doument를 찾아
`document is not defined` 에러가 발생했습니다.(하이드레이션 관련 issue) 
=> `mounted` useState변수로 플래그를 걸어서 해결했습니다! 관련 커밋 49393d2e41b4092b4fe892cb52a792dcbca4e43b
https://univdev.page/posts/nextjs-portal/

## 🟢 완료 조건
- 모달 외부(백드롭)를 클릭했을 때 모달이 꺼진다.
- esc 키를 눌렀을 때 모달이 꺼진다.
- 모달창이 켜졌을 때 외부 스크롤이 방지된다.
- 모달을 커스텀해서 사용할 수 있다.

## ✍ 궁금한 점
- esc 키 이벤트와 스크롤 방지는 훅으로 분리할 수 있을 것 같아서 useModal hook으로 분리해봤는데 어떤가요?
- Portal을 컴포넌트화할 수 있었는데, 저희 프로젝트 상황에는 모달에만 적용될 것 같아 모달에 바로 적용시켰습니다. 따로 안만들어도 괜찮은지 유현님 생각이 궁금합니다!

테스트용 코드 마지막 커밋에 포함시켜뒀어요! 머지되기 전에 날리고 머지할게요~! layout 페이지로 들어가시면 됩니당🙌
