### PR TITLE
[BE] feat#7 컨테이너 생성/컨테이너 명령 실행

### DIFF
--- a/packages/backend/.gitignore
+++ b/packages/backend/.gitignore
@@ -33,3 +33,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.env

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
@@ -29,6 +30,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.6",
+    "ssh2": "^1.14.0",
     "typeorm": "^0.3.17"
   },
   "devDependencies": {
@@ -38,6 +40,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
+    "@types/ssh2": "^1",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -2,11 +2,18 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import { typeOrmConfig } from './configs/typeorm.config';
 import { QuizzesModule } from './quizzes/quizzes.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeOrmConfig), QuizzesModule],
+  imports: [
+    TypeOrmModule.forRoot(typeOrmConfig),
+    QuizzesModule,
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/packages/backend/src/containers/containers.module.ts
+++ b/packages/backend/src/containers/containers.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ContainersService } from './containers.service';
+
+@Module({
+  providers: [ContainersService],
+  exports: [ContainersService],
+})
+export class ContainersModule {}

--- a/packages/backend/src/containers/containers.service.spec.ts
+++ b/packages/backend/src/containers/containers.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContainersService } from './containers.service';
+
+describe('ContainersService', () => {
+  let service: ContainersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ContainersService],
+    }).compile();
+
+    service = module.get<ContainersService>(ContainersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -7,10 +7,7 @@ import { Client } from 'ssh2';
 export class ContainersService {
   constructor(private configService: ConfigService) {}
 
-  async runSSHCommand(
-    container: string,
-    command: string,
-  ): Promise<CommandResponseDto> {
+  private async getSSH(): Promise<Client> {
     const conn = new Client();
 
     await new Promise<void>((resolve, reject) => {
@@ -25,35 +22,73 @@ export class ContainersService {
         });
     });
 
+    return conn;
+  }
+
+  private async executeSSHCommand(
+    command: string,
+  ): Promise<{ stdoutData: string; stderrData: string }> {
+    const conn: Client = await this.getSSH();
+
     return new Promise((resolve, reject) => {
-      conn.exec(
-        `docker exec -w ~/quiz/ ${container} ${command}`,
-        (err, stream) => {
-          if (err) {
-            reject(new Error('SSH command execution Server error'));
-            return;
-          }
-
-          let stdoutData = '';
-          let stderrData = '';
-          stream
-            .on('close', () => {
-              conn.end();
-              if (stderrData) {
-                resolve({ message: stderrData, result: 'fail' });
-              } else {
-                resolve({ message: stdoutData, result: 'success' });
-              }
-            })
-            .on('data', (chunk) => {
-              stdoutData += chunk;
-            });
-
-          stream.stderr.on('data', (chunk) => {
-            stderrData += chunk;
+      conn.exec(command, (err, stream) => {
+        if (err) {
+          reject(new Error('SSH command execution Server error'));
+          return;
+        }
+        let stdoutData = '';
+        let stderrData = '';
+        stream
+          .on('close', () => {
+            conn.end();
+            resolve({ stdoutData, stderrData });
+          })
+          .on('data', (chunk) => {
+            stdoutData += chunk;
           });
-        },
-      );
+
+        stream.stderr.on('data', (chunk) => {
+          stderrData += chunk;
+        });
+      });
     });
+  }
+
+  async runGitCommand(
+    container: string,
+    command: string,
+  ): Promise<CommandResponseDto> {
+    const { stdoutData, stderrData } = await this.executeSSHCommand(
+      `docker exec -w ~/quiz/ ${container} ${command}`,
+    );
+
+    if (stderrData) {
+      return { message: stderrData, result: 'fail' };
+    }
+
+    return { message: stdoutData, result: 'success' };
+  }
+
+  async getContainer(quizId: number): Promise<string> {
+    // 일단은 컨테이너를 생성해 준다.
+    // 차후에는 준비된 컨테이너 중 하나를 선택해서 준다.
+    // quizId에 대한 유효성 검사는 이미 끝났다(이미 여기서는 DB 접근 불가)
+
+    const host: string = this.configService.get<string>(
+      'CONTAINER_SSH_USERNAME',
+    );
+
+    const createContainerCommand = `docker run -itd mergemasters/alpine-git:0.1 /bin/sh`;
+    const { stdoutData: containerId } = await this.executeSSHCommand(
+      createContainerCommand,
+    );
+
+    const createDirectoryCommand = `docker exec ${containerId} mkdir -p /${host}/quiz/`;
+    await this.executeSSHCommand(createDirectoryCommand);
+
+    const copyFilesCommand = `docker cp ~/quizzes/${quizId}/ ${containerId}:/${host}/quiz/`;
+    await this.executeSSHCommand(copyFilesCommand);
+
+    return containerId;
   }
 }

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CommandResponseDto } from 'src/quizzes/dto/command-response.dto';
+import { Client } from 'ssh2';
+
+@Injectable()
+export class ContainersService {
+  constructor(private configService: ConfigService) {}
+
+  async runSSHCommand(
+    container: string,
+    command: string,
+  ): Promise<CommandResponseDto> {
+    const conn = new Client();
+
+    await new Promise<void>((resolve, reject) => {
+      conn
+        .on('ready', () => resolve())
+        .on('error', reject)
+        .connect({
+          host: this.configService.get<string>('CONTAINER_SSH_HOST'),
+          port: this.configService.get<number>('CONTAINER_SSH_PORT'),
+          username: this.configService.get<string>('CONTAINER_SSH_USERNAME'),
+          password: this.configService.get<string>('CONTAINER_SSH_PASSWORD'),
+        });
+    });
+
+    return new Promise((resolve, reject) => {
+      conn.exec(
+        `docker exec -w ~/quiz/ ${container} ${command}`,
+        (err, stream) => {
+          if (err) {
+            reject(new Error('SSH command execution Server error'));
+            return;
+          }
+
+          let stdoutData = '';
+          let stderrData = '';
+          stream
+            .on('close', () => {
+              conn.end();
+              if (stderrData) {
+                resolve({ message: stderrData, result: 'fail' });
+              } else {
+                resolve({ message: stdoutData, result: 'success' });
+              }
+            })
+            .on('data', (chunk) => {
+              stdoutData += chunk;
+            });
+
+          stream.stderr.on('data', (chunk) => {
+            stderrData += chunk;
+          });
+        },
+      );
+    });
+  }
+}

--- a/packages/backend/src/quizzes/dto/command-request.dto.ts
+++ b/packages/backend/src/quizzes/dto/command-request.dto.ts
@@ -1,0 +1,3 @@
+export class CommandRequestDto {
+  command: string;
+}

--- a/packages/backend/src/quizzes/dto/command-response.dto.ts
+++ b/packages/backend/src/quizzes/dto/command-response.dto.ts
@@ -1,0 +1,5 @@
+export class CommandResponseDto {
+  message: string;
+  result: 'success' | 'fail' | 'vi';
+  graph?: string;
+}

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -1,7 +1,17 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { QuizDto } from './dto/quiz.dto';
 import { QuizzesService } from './quizzes.service';
 import { QuizzesDto } from './dto/quizzes.dto';
+import { CommandRequestDto } from './dto/command-request.dto';
+import { CommandResponseDto } from './dto/command-response.dto';
 
 @Controller('api/v1/quizzes')
 export class QuizzesController {
@@ -17,5 +27,30 @@ export class QuizzesController {
   @Get('/')
   async getProblemsGroupedByCategory(): Promise<QuizzesDto> {
     return this.quizService.findAllProblemsGroupedByCategory();
+  }
+
+  @Post(':id/command')
+  async runSSHCommand(
+    @Param('id') id: number,
+    @Body() execCommandDto: CommandRequestDto,
+  ): Promise<CommandResponseDto> {
+    try {
+      const { message, result } = await this.quizService.runSSHCommand(
+        execCommandDto.command,
+      );
+      return {
+        message,
+        result,
+        // graph: 필요한 경우 여기에 추가
+      };
+    } catch (error) {
+      throw new HttpException(
+        {
+          message: 'Internal Server Error',
+          result: 'fail',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 }

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -30,12 +30,12 @@ export class QuizzesController {
   }
 
   @Post(':id/command')
-  async runSSHCommand(
+  async runGitCommand(
     @Param('id') id: number,
     @Body() execCommandDto: CommandRequestDto,
   ): Promise<CommandResponseDto> {
     try {
-      const { message, result } = await this.quizService.runSSHCommand(
+      const { message, result } = await this.quizService.runGitCommand(
         execCommandDto.command,
       );
       return {

--- a/packages/backend/src/quizzes/quizzes.module.ts
+++ b/packages/backend/src/quizzes/quizzes.module.ts
@@ -4,9 +4,10 @@ import { QuizzesService } from './quizzes.service';
 import { Quiz } from './entity/quiz.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Category } from './entity/category.entity';
+import { ContainersModule } from '../containers/containers.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Quiz, Category])],
+  imports: [TypeOrmModule.forFeature([Quiz, Category]), ContainersModule],
   controllers: [QuizzesController],
   providers: [QuizzesService],
 })

--- a/packages/backend/src/quizzes/quizzes.service.ts
+++ b/packages/backend/src/quizzes/quizzes.service.ts
@@ -5,6 +5,8 @@ import { Repository } from 'typeorm';
 import { QuizDto } from './dto/quiz.dto';
 import { CategoryQuizzesDto, QuizzesDto } from './dto/quizzes.dto';
 import { Category } from './entity/category.entity';
+import { ContainersService } from 'src/containers/containers.service';
+import { CommandResponseDto } from './dto/command-response.dto';
 
 @Injectable()
 export class QuizzesService {
@@ -13,6 +15,7 @@ export class QuizzesService {
     private quizRepository: Repository<Quiz>,
     @InjectRepository(Category)
     private categoryRepository: Repository<Category>,
+    private containerService: ContainersService,
   ) {}
   async getQuizById(id: number): Promise<QuizDto> {
     const quiz = await this.quizRepository.findOne({
@@ -54,5 +57,9 @@ export class QuizzesService {
     const quizzesDtos: QuizzesDto = { categories: categoryQuizzesDtos };
 
     return quizzesDtos;
+  }
+
+  async runSSHCommand(command: string): Promise<CommandResponseDto> {
+    return this.containerService.runSSHCommand('testContainer', command);
   }
 }

--- a/packages/backend/src/quizzes/quizzes.service.ts
+++ b/packages/backend/src/quizzes/quizzes.service.ts
@@ -59,7 +59,15 @@ export class QuizzesService {
     return quizzesDtos;
   }
 
-  async runSSHCommand(command: string): Promise<CommandResponseDto> {
-    return this.containerService.runSSHCommand('testContainer', command);
+  async runGitCommand(command: string): Promise<CommandResponseDto> {
+    // 세션 검색
+
+    // 세션 없으면 or 세션에 할당된 컨테이너 없으면 컨테이너 생성
+    // await this.containerService.getContainer(quizId);
+
+    // 컨테이너 생성, 세션에 할당하고 DB 저장
+
+    // 최종 실행
+    return this.containerService.runGitCommand('testContainer', command);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,6 +976,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/config@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@nestjs/config@npm:3.1.1"
+  dependencies:
+    dotenv: "npm:16.3.1"
+    dotenv-expand: "npm:10.0.0"
+    lodash: "npm:4.17.21"
+    uuid: "npm:9.0.0"
+  peerDependencies:
+    "@nestjs/common": ^8.0.0 || ^9.0.0 || ^10.0.0
+    reflect-metadata: ^0.1.13
+  checksum: d8e463c3000e2a412f2a69f57dc49706df1c7653d14e70e9261df4b3e99d69acb844cc417609354d07731a6b2bbada73db1e5263ba29d573f60deb9a173476eb
+  languageName: node
+  linkType: hard
+
 "@nestjs/core@npm:^10.0.0":
   version: 10.2.8
   resolution: "@nestjs/core@npm:10.2.8"
@@ -1438,6 +1453,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^18.11.18":
+  version: 18.18.10
+  resolution: "@types/node@npm:18.18.10"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: dff9f4bd39cf551f168d92abb6ecb8d8bd1b404454fef3472b95b27214a691bede53b270740ec95acf5c833716dbb024dbb644823da21096c41ecaa3c240b0cb
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.9.10
   resolution: "@types/qs@npm:6.9.10"
@@ -1477,6 +1501,15 @@ __metadata:
     "@types/mime": "npm:*"
     "@types/node": "npm:*"
   checksum: 811d1a2f7e74a872195e7a013bcd87a2fb1edf07eaedcb9dcfd20c1eb4bc56ad4ea0d52141c13192c91ccda7c8aeb8a530d8a7e60b9c27f5990d7e62e0fecb03
+  languageName: node
+  linkType: hard
+
+"@types/ssh2@npm:^1":
+  version: 1.11.16
+  resolution: "@types/ssh2@npm:1.11.16"
+  dependencies:
+    "@types/node": "npm:^18.11.18"
+  checksum: 6e85d80beba6364008b9b6df2318be1a0a371b3aa4a57894ab88d3faa377c903cb1b7f702bea0e7913beb97bf23627a0aace539b2f1446ee460b308ea55e8f38
   languageName: node
   linkType: hard
 
@@ -2136,6 +2169,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "asn1@npm:0.2.6"
+  dependencies:
+    safer-buffer: "npm:~2.1.0"
+  checksum: 00c8a06c37e548762306bcb1488388d2f76c74c36f70c803f0c081a01d3bdf26090fc088cd812afc5e56a6d49e33765d451a5f8a68ab9c2b087eba65d2e980e0
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -2225,6 +2267,7 @@ __metadata:
   dependencies:
     "@nestjs/cli": "npm:^10.0.0"
     "@nestjs/common": "npm:^10.0.0"
+    "@nestjs/config": "npm:^3.1.1"
     "@nestjs/core": "npm:^10.0.0"
     "@nestjs/platform-express": "npm:^10.0.0"
     "@nestjs/schematics": "npm:^10.0.0"
@@ -2233,6 +2276,7 @@ __metadata:
     "@types/express": "npm:^4.17.17"
     "@types/jest": "npm:^29.5.2"
     "@types/node": "npm:^20.3.1"
+    "@types/ssh2": "npm:^1"
     "@types/supertest": "npm:^2.0.12"
     "@typescript-eslint/eslint-plugin": "npm:^6.0.0"
     "@typescript-eslint/parser": "npm:^6.0.0"
@@ -2247,6 +2291,7 @@ __metadata:
     rxjs: "npm:^7.8.1"
     source-map-support: "npm:^0.5.21"
     sqlite3: "npm:^5.1.6"
+    ssh2: "npm:^1.14.0"
     supertest: "npm:^6.3.3"
     ts-jest: "npm:^29.1.0"
     ts-loader: "npm:^9.4.3"
@@ -2268,6 +2313,15 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"bcrypt-pbkdf@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "bcrypt-pbkdf@npm:1.0.2"
+  dependencies:
+    tweetnacl: "npm:^0.14.3"
+  checksum: ddfe85230b32df25aeebfdccfbc61d3bc493ace49c884c9c68575de1f5dcf733a5d7de9def3b0f318b786616b8d85bad50a28b1da1750c43e0012c93badcc148
   languageName: node
   linkType: hard
 
@@ -2429,6 +2483,13 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.2.1"
   checksum: 2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
+  languageName: node
+  linkType: hard
+
+"buildcheck@npm:~0.0.6":
+  version: 0.0.6
+  resolution: "buildcheck@npm:0.0.6"
+  checksum: 8cbdb89f41bc484b8325f4828db4135b206a0dffb641eb6cdb2b7022483c45dd0e5aac6d820c9a67bdd2caab3a02c76d7ceec7bd9ec494b5a2270d2806b01a76
   languageName: node
   linkType: hard
 
@@ -2939,6 +3000,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cpu-features@npm:~0.0.8":
+  version: 0.0.9
+  resolution: "cpu-features@npm:0.0.9"
+  dependencies:
+    buildcheck: "npm:~0.0.6"
+    nan: "npm:^2.17.0"
+    node-gyp: "npm:latest"
+  checksum: e12aa8b791d2db6572d23553c2eb14dfe90c80fa69c788fcf8f2a5dc373b7ac1c99dd04292677751746cafe51a67d62eb09fd9f88502e37830fe602c7e582ca8
+  languageName: node
+  linkType: hard
+
 "create-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "create-jest@npm:29.7.0"
@@ -3163,7 +3235,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.3":
+"dotenv-expand@npm:10.0.0":
+  version: 10.0.0
+  resolution: "dotenv-expand@npm:10.0.0"
+  checksum: 298f5018e29cfdcb0b5f463ba8e8627749103fbcf6cf81c561119115754ed582deee37b49dfc7253028aaba875ab7aea5fa90e5dac88e511d009ab0e6677924e
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:16.3.1, dotenv@npm:^16.0.3":
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
   checksum: b95ff1bbe624ead85a3cd70dbd827e8e06d5f05f716f2d0cbc476532d54c7c9469c3bc4dd93ea519f6ad711cb522c00ac9a62b6eb340d5affae8008facc3fbd7
@@ -5345,7 +5424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
+"lodash@npm:4.17.21, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -5813,6 +5892,15 @@ __metadata:
     object-assign: "npm:^4.0.1"
     thenify-all: "npm:^1.0.0"
   checksum: 103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.17.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 9209d80134fdb98c0afe35c1372d2b930a0a8d3c52706cb5e4257a27e9845c375f7a8daedadadec8d6403ca2eebb3b37d362ff5d1ec03249462abf65fef2a148
   languageName: node
   linkType: hard
 
@@ -6750,7 +6838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -7033,6 +7121,23 @@ __metadata:
     node-gyp:
       optional: true
   checksum: 85f1dd1f4b9fa906578330e7badc1116c61ef4e7c64a09897268923f5c9ff4ae1e0a447dd4594c0f8c3b20a410fcc5d8d00d1056225a5186c57ea7f7c9b18974
+  languageName: node
+  linkType: hard
+
+"ssh2@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "ssh2@npm:1.14.0"
+  dependencies:
+    asn1: "npm:^0.2.6"
+    bcrypt-pbkdf: "npm:^1.0.2"
+    cpu-features: "npm:~0.0.8"
+    nan: "npm:^2.17.0"
+  dependenciesMeta:
+    cpu-features:
+      optional: true
+    nan:
+      optional: true
+  checksum: be2f98c967557df70d21ab16f278d6e276de3678b655bcf385efdd1d38202e1b89d143cf89f975b88225dfca6c7b9f18e9b32f8ebc76f3634b6478554e74e844
   languageName: node
   linkType: hard
 
@@ -7546,6 +7651,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tweetnacl@npm:^0.14.3":
+  version: 0.14.5
+  resolution: "tweetnacl@npm:0.14.5"
+  checksum: 4612772653512c7bc19e61923fbf42903f5e0389ec76a4a1f17195859d114671ea4aa3b734c2029ce7e1fa7e5cc8b80580f67b071ecf0b46b5636d030a0102a2
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -7820,6 +7932,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
+  languageName: node
+  linkType: hard
+
+"uuid@npm:9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8867e438990d1d33ac61093e2e4e3477a2148b844e4fa9e3c2360fa4399292429c4b6ec64537eb1659c97b2d10db349c673ad58b50e2824a11e0d3630de3c056
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #7 

## ✅ 작업 내용

### 실행 중인 컨테이너에 git 명령을 실행하고 결과 받기

- 현재 컨테이너 정보를 동적으로 알 수 없기 때문에(세션이나 DB 없음) 일단 'testContainer'라는 컨테이너에 고정으로 명령이 갑니다.
- 현재 컨테이너는 commit 1개, add된 파일 1개, untracked된 파일 1개를 가지고 있습니다(사진 첨부)
- commit을 위해 --global설정도 해 두었습니다(user: MergeMaster, email: mergemaster@gitchallenge.com)

### 컨테이너 서버 로컬의 문제 디렉토리를 기반으로 문제 컨테이너 동적 생성

- 현재 API가 붙어 있지 않고 코드만 있습니다. 수동으로 테스트 했으며, DB가 붙고 세션 분간이 되어야 이 코드를 사용할 수 있습니다.
- e2e 흐름
  1. 명령어 요청이 오면 세션을 확인
  2. 세션이 없거나 세션에 할당된 컨테이너가 없다면(죽었다면) 컨테이너 생성
    1. docker run
    2. 컨테이너 서버 로컬(~/quizzes/${quizId}) 에서 문제 컨테이너 내부(/${user}/quiz)로 cp
  3. 이제 컨테이너는 무조건 있으니 명령 실행
  4. 결과 리턴

* 흐름에서 나타냈듯, 당장 동작을 위해서 컨테이너 서버 로컬 ~/quizzes/ 안에 문제별로 문제 상황을 꾸며 놓으면 됩니다.아마 이게 최선일 듯 싶네요?

## 📸 스크린샷(BE도!)

* git log
  <img width="1002" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/5bf355e2-b39d-43d1-a29d-6df26dffdb6c">
  
* git status
  <img width="1002" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/59fd7f12-86c3-484c-95e3-58c675adeff5">
  
* git branch
  <img width="1009" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/7441a67b-2a62-4667-b4ac-4900aded1ad9">

* MergeMaster 최고
  <img width="1009" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/ef409ffb-682e-4134-b235-8b5abd2e9a12">


## 📌 이슈 사항

- Slack에도 간단하게 공지했지만, 현재 success/fail 여부는 stdout, stderr로 구분하고 있습니다
- 이 구분이 우리의 인식과 조금 다른 경우가 있습니다. 하지만 어차피 실행된 결과 문자열을 반환하기 때문에 당장 동작에는 무리 없을 것 같습니다.
- 진짜 서버 에러(500)시에는 `message: Internal Server Error`, `result: fail` 이 리턴됩니다.

## 🟢 완료 조건

- 입력에 대해 명령이 실행되고 결과가 반환됨 (현재 명령 검증 없음)
- 명령의 실패와 성공을 구분하여 리턴
- 동적으로 문제 컨테이너가 생성되고 생성 시 해당 컨테이너의 ID를 확보할 수 있음

## ✍ 궁금한 점

* DTO는 일단 /quizzes 아래에 생성했어요. 가장 좋은지는 모르겠는데 나쁘지는 않은 것 같아요?