### PR TITLE
[FE] feat#69 Terminal 컴포넌트

### DIFF
--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -1,0 +1,35 @@
+import { type KeyboardEventHandler, forwardRef } from "react";
+
+import classnames from "../../utils/classnames";
+
+import Prompt from "./Prompt";
+import * as styles from "./Terminal.css";
+
+interface CommandInputProps {
+  handleInput: KeyboardEventHandler;
+}
+
+const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
+  ({ handleInput }, ref) => (
+    <div className={styles.commandInputContainer}>
+      <span id="commandLabel" style={{ display: "none" }}>
+        Enter git command
+      </span>
+      <Prompt />
+      <span
+        className={classnames(styles.commandInput, styles.stdin)}
+        contentEditable
+        onKeyDown={handleInput}
+        role="textbox"
+        aria-placeholder="git command"
+        aria-labelledby="commandLabel"
+        tabIndex={0}
+        ref={ref}
+      />
+    </div>
+  )
+);
+
+CommandInput.displayName = "CommandInput";
+
+export default CommandInput;

--- a/packages/frontend/src/components/terminal/Prompt.tsx
+++ b/packages/frontend/src/components/terminal/Prompt.tsx
@@ -1,0 +1,5 @@
+import { prompt as promptStyle } from "./Terminal.css";
+
+export default function Prompt() {
+  return <span className={promptStyle}>$</span>;
+}

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -15,9 +15,9 @@ export const hr = style({
   height: hrHeight,
   margin: 0,
   border: "none",
-  borderTop: `1px solid ${color.$scale.grey600}`,
-  borderBottom: `1px solid ${color.$scale.grey600}`,
-  backgroundColor: color.$scale.grey300,
+  borderTop: `1px solid ${color.$semantic.border}`,
+  borderBottom: `1px solid ${color.$semantic.border}`,
+  backgroundColor: color.$scale.grey100,
 });
 
 export const terminalContainer = style([
@@ -26,20 +26,8 @@ export const terminalContainer = style([
     height: `calc(100% - ${hrHeight})`,
     padding: "20px 10px 0",
     overflowY: "auto",
-
-    "::-webkit-scrollbar": {
-      width: 5,
-      backgroundColor: "transparent",
-    },
-
-    "::-webkit-scrollbar-thumb": {
-      borderRadius: 5,
-      backgroundColor: color.$scale.grey100,
-    },
-
-    "::-webkit-scrollbar-button": {
-      display: "none",
-    },
+    color: color.$scale.grey900,
+    backgroundColor: color.$scale.grey00,
   },
 ]);
 

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -1,0 +1,71 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../design-system/tokens/color";
+import typography from "../../design-system/tokens/typography";
+import { flexAlignCenter } from "../../design-system/tokens/utils.css";
+
+const hrHeight = "20px";
+
+export const container = style({
+  height: 250,
+  width: "100%",
+});
+
+export const hr = style({
+  height: hrHeight,
+  margin: 0,
+  border: "none",
+  borderTop: `1px solid ${color.$scale.grey600}`,
+  borderBottom: `1px solid ${color.$scale.grey600}`,
+  backgroundColor: color.$scale.grey300,
+});
+
+export const terminalContainer = style([
+  typography.$semantic.caption1Regular,
+  {
+    height: `calc(100% - ${hrHeight})`,
+    padding: "20px 10px 0",
+    overflowY: "auto",
+
+    "::-webkit-scrollbar": {
+      width: 5,
+      backgroundColor: "transparent",
+    },
+
+    "::-webkit-scrollbar-thumb": {
+      borderRadius: 5,
+      backgroundColor: color.$scale.grey100,
+    },
+
+    "::-webkit-scrollbar-button": {
+      display: "none",
+    },
+  },
+]);
+
+export const commandInputContainer = style([
+  flexAlignCenter,
+  {
+    width: "100%",
+    position: "relative",
+  },
+]);
+
+export const prompt = style({
+  position: "absolute",
+  top: 1,
+  left: 0,
+  paddingRight: 4,
+});
+
+export const stdinContainer = style({ position: "relative" });
+
+export const stdin = style({
+  display: "block",
+  textIndent: 10,
+});
+
+export const commandInput = style({
+  flex: 1,
+  outline: 0,
+});

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,5 +1,6 @@
 import { type KeyboardEventHandler, useEffect, useRef } from "react";
 
+import { ENTER_KEY_CODE } from "../../constants";
 import type { TerminalContentType } from "../../types/terminalType";
 import { scrollIntoView } from "../../utils/scroll";
 
@@ -20,7 +21,7 @@ export default function Terminal({
 
   const handleStandardInput: KeyboardEventHandler = (event) => {
     const { key, currentTarget } = event;
-    if (key !== "Enter") {
+    if (key !== ENTER_KEY_CODE) {
       return;
     }
 

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,14 +1,8 @@
-import {
-  type KeyboardEventHandler,
-  RefObject,
-  forwardRef,
-  useEffect,
-  useRef,
-} from "react";
+import { type KeyboardEventHandler, RefObject, useEffect, useRef } from "react";
 
-import classnames from "../../utils/classnames";
-
+import CommandInput from "./CommandInput";
 import * as styles from "./Terminal.css";
+import TerminalContent from "./TerminalContent";
 
 type TerminalContentType =
   | STDINContentType
@@ -49,8 +43,6 @@ export default function Terminal({
     event.preventDefault();
   };
 
-  const terminalContent = contentArray.map(toTerminalContentComponent);
-
   useEffect(() => {
     scrollIntoView(commandInputRef);
   }, [contentArray]);
@@ -59,75 +51,13 @@ export default function Terminal({
     <div className={styles.container}>
       <div className={styles.hr} />
       <div className={styles.terminalContainer}>
-        <div>{terminalContent}</div>
+        <TerminalContent contentArray={contentArray} />
+
         <CommandInput handleInput={handleSTDIN} ref={commandInputRef} />
       </div>
     </div>
   );
 }
-
-const contentMap = {
-  stdin: StdInContent,
-  stdout: StdOutContent,
-  stderr: StdErrContent,
-};
-
-function Prompt() {
-  return <span className={styles.prompt}>$</span>;
-}
-
-function StdInContent({ content }: Pick<STDINContentType, "content">) {
-  return (
-    <div className={styles.stdinContainer}>
-      <Prompt />
-      <span className={styles.stdin}>{content}</span>
-    </div>
-  );
-}
-
-function StdOutContent({ content }: Pick<STDOUTContentType, "content">) {
-  return (
-    <div>
-      <span>{content}</span>
-    </div>
-  );
-}
-
-function StdErrContent({ content }: Pick<STDERRContentType, "content">) {
-  return (
-    <div className={styles.stdinContainer}>
-      <Prompt />
-      <span className={styles.stdin}>{content}</span>
-    </div>
-  );
-}
-
-interface CommandInputProps {
-  handleInput: KeyboardEventHandler;
-}
-
-const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
-  ({ handleInput }, ref) => (
-    <div className={styles.commandInputContainer}>
-      <span id="commandLabel" style={{ display: "none" }}>
-        Enter git command
-      </span>
-      <Prompt />
-      <span
-        className={classnames(styles.commandInput, styles.stdin)}
-        contentEditable
-        onKeyDown={handleInput}
-        role="textbox"
-        aria-placeholder="git command"
-        aria-labelledby="commandLabel"
-        tabIndex={0}
-        ref={ref}
-      />
-    </div>
-  ),
-);
-
-CommandInput.displayName = "CommandInput";
 
 function scrollIntoView<T extends Element>(ref: RefObject<T>) {
   const $element = ref.current;
@@ -136,12 +66,4 @@ function scrollIntoView<T extends Element>(ref: RefObject<T>) {
   }
 
   $element.scrollIntoView();
-}
-
-function toTerminalContentComponent(
-  { type, content }: TerminalContentType,
-  index: number,
-) {
-  const Content = contentMap[type];
-  return <Content key={[type, index].join("-")} content={content} />;
 }

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,0 +1,147 @@
+import {
+  type KeyboardEventHandler,
+  RefObject,
+  forwardRef,
+  useEffect,
+  useRef,
+} from "react";
+
+import classnames from "../../utils/classnames";
+
+import * as styles from "./Terminal.css";
+
+type TerminalContentType =
+  | STDINContentType
+  | STDOUTContentType
+  | STDERRContentType;
+
+type STDContentType<T> = { type: T; content: string };
+type STDINContentType = STDContentType<"stdin">;
+type STDOUTContentType = STDContentType<"stdout">;
+type STDERRContentType = STDContentType<"stderr">;
+
+interface TerminalProps {
+  contentArray: TerminalContentType[];
+  onStandardInput: (input: string) => void;
+}
+
+export default function Terminal({
+  contentArray,
+  onStandardInput,
+}: TerminalProps) {
+  const commandInputRef = useRef<HTMLSpanElement>(null);
+
+  const handleSTDIN: KeyboardEventHandler = (event) => {
+    const { key, currentTarget } = event;
+    if (key !== "Enter") {
+      return;
+    }
+
+    const value = (currentTarget.textContent ?? "").trim();
+    if (!value) {
+      event.preventDefault();
+      return;
+    }
+
+    onStandardInput(value);
+
+    currentTarget.textContent = "";
+    event.preventDefault();
+  };
+
+  const terminalContent = contentArray.map(toTerminalContentComponent);
+
+  useEffect(() => {
+    scrollIntoView(commandInputRef);
+  }, [contentArray]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.hr} />
+      <div className={styles.terminalContainer}>
+        <div>{terminalContent}</div>
+        <CommandInput handleInput={handleSTDIN} ref={commandInputRef} />
+      </div>
+    </div>
+  );
+}
+
+const contentMap = {
+  stdin: StdInContent,
+  stdout: StdOutContent,
+  stderr: StdErrContent,
+};
+
+function Prompt() {
+  return <span className={styles.prompt}>$</span>;
+}
+
+function StdInContent({ content }: Pick<STDINContentType, "content">) {
+  return (
+    <div className={styles.stdinContainer}>
+      <Prompt />
+      <span className={styles.stdin}>{content}</span>
+    </div>
+  );
+}
+
+function StdOutContent({ content }: Pick<STDOUTContentType, "content">) {
+  return (
+    <div>
+      <span>{content}</span>
+    </div>
+  );
+}
+
+function StdErrContent({ content }: Pick<STDERRContentType, "content">) {
+  return (
+    <div className={styles.stdinContainer}>
+      <Prompt />
+      <span className={styles.stdin}>{content}</span>
+    </div>
+  );
+}
+
+interface CommandInputProps {
+  handleInput: KeyboardEventHandler;
+}
+
+const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
+  ({ handleInput }, ref) => (
+    <div className={styles.commandInputContainer}>
+      <span id="commandLabel" style={{ display: "none" }}>
+        Enter git command
+      </span>
+      <Prompt />
+      <span
+        className={classnames(styles.commandInput, styles.stdin)}
+        contentEditable
+        onKeyDown={handleInput}
+        role="textbox"
+        aria-placeholder="git command"
+        aria-labelledby="commandLabel"
+        tabIndex={0}
+        ref={ref}
+      />
+    </div>
+  ),
+);
+
+CommandInput.displayName = "CommandInput";
+
+function scrollIntoView<T extends Element>(ref: RefObject<T>) {
+  const $element = ref.current;
+  if (!$element) {
+    return;
+  }
+
+  $element.scrollIntoView();
+}
+
+function toTerminalContentComponent(
+  { type, content }: TerminalContentType,
+  index: number,
+) {
+  const Content = contentMap[type];
+  return <Content key={[type, index].join("-")} content={content} />;
+}

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -10,13 +10,10 @@ import TerminalContent from "./TerminalContent";
 
 interface TerminalProps {
   contentArray: TerminalContentType[];
-  onStandardInput: (input: string) => void;
+  onTerminal: (input: string) => void;
 }
 
-export default function Terminal({
-  contentArray,
-  onStandardInput,
-}: TerminalProps) {
+export default function Terminal({ contentArray, onTerminal }: TerminalProps) {
   const inputRef = useRef<HTMLSpanElement>(null);
 
   const handleStandardInput: KeyboardEventHandler = (event) => {
@@ -32,7 +29,7 @@ export default function Terminal({
       return;
     }
 
-    onStandardInput(value);
+    onTerminal(value);
 
     currentTarget.textContent = "";
   };

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,18 +1,11 @@
-import { type KeyboardEventHandler, RefObject, useEffect, useRef } from "react";
+import { type KeyboardEventHandler, useEffect, useRef } from "react";
+
+import type { TerminalContentType } from "../../types/terminalType";
+import { scrollIntoView } from "../../utils/scroll";
 
 import CommandInput from "./CommandInput";
 import * as styles from "./Terminal.css";
 import TerminalContent from "./TerminalContent";
-
-type TerminalContentType =
-  | STDINContentType
-  | STDOUTContentType
-  | STDERRContentType;
-
-type STDContentType<T> = { type: T; content: string };
-type STDINContentType = STDContentType<"stdin">;
-type STDOUTContentType = STDContentType<"stdout">;
-type STDERRContentType = STDContentType<"stderr">;
 
 interface TerminalProps {
   contentArray: TerminalContentType[];
@@ -23,28 +16,28 @@ export default function Terminal({
   contentArray,
   onStandardInput,
 }: TerminalProps) {
-  const commandInputRef = useRef<HTMLSpanElement>(null);
+  const inputRef = useRef<HTMLSpanElement>(null);
 
-  const handleSTDIN: KeyboardEventHandler = (event) => {
+  const handleStandardInput: KeyboardEventHandler = (event) => {
     const { key, currentTarget } = event;
     if (key !== "Enter") {
       return;
     }
 
+    event.preventDefault();
+
     const value = (currentTarget.textContent ?? "").trim();
     if (!value) {
-      event.preventDefault();
       return;
     }
 
     onStandardInput(value);
 
     currentTarget.textContent = "";
-    event.preventDefault();
   };
 
   useEffect(() => {
-    scrollIntoView(commandInputRef);
+    scrollIntoView(inputRef);
   }, [contentArray]);
 
   return (
@@ -53,7 +46,7 @@ export default function Terminal({
       <div className={styles.terminalContainer}>
         <TerminalContent contentArray={contentArray} />
 
-        <CommandInput handleInput={handleSTDIN} ref={commandInputRef} />
+        <CommandInput handleInput={handleStandardInput} ref={inputRef} />
       </div>
     </div>
   );

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,6 +1,6 @@
 import { type KeyboardEventHandler, useEffect, useRef } from "react";
 
-import { ENTER_KEY_CODE } from "../../constants";
+import { ENTER_KEY } from "../../constants";
 import type { TerminalContentType } from "../../types/terminalType";
 import { scrollIntoView } from "../../utils/scroll";
 
@@ -21,7 +21,7 @@ export default function Terminal({
 
   const handleStandardInput: KeyboardEventHandler = (event) => {
     const { key, currentTarget } = event;
-    if (key !== ENTER_KEY_CODE) {
+    if (key !== ENTER_KEY) {
       return;
     }
 

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -58,12 +58,3 @@ export default function Terminal({
     </div>
   );
 }
-
-function scrollIntoView<T extends Element>(ref: RefObject<T>) {
-  const $element = ref.current;
-  if (!$element) {
-    return;
-  }
-
-  $element.scrollIntoView();
-}

--- a/packages/frontend/src/components/terminal/TerminalContent.tsx
+++ b/packages/frontend/src/components/terminal/TerminalContent.tsx
@@ -1,0 +1,63 @@
+import Prompt from "./Prompt";
+import * as styles from "./Terminal.css";
+
+interface TerminalContentProps {
+  contentArray: TerminalContentType[];
+}
+
+type TerminalContentType =
+  | STDINContentType
+  | STDOUTContentType
+  | STDERRContentType;
+
+type STDContentType<T> = { type: T; content: string };
+type STDINContentType = STDContentType<"stdin">;
+type STDOUTContentType = STDContentType<"stdout">;
+type STDERRContentType = STDContentType<"stderr">;
+
+export default function TerminalContent({
+  contentArray,
+}: TerminalContentProps) {
+  const content = contentArray.map(toTerminalContentComponent);
+  return <div>{content}</div>;
+}
+
+const contentMap = {
+  stdin: StdInContent,
+  stdout: StdOutContent,
+  stderr: StdErrContent,
+};
+
+function StdInContent({ content }: Pick<STDINContentType, "content">) {
+  return (
+    <div className={styles.stdinContainer}>
+      <Prompt />
+      <span className={styles.stdin}>{content}</span>
+    </div>
+  );
+}
+
+function StdOutContent({ content }: Pick<STDOUTContentType, "content">) {
+  return (
+    <div>
+      <span>{content}</span>
+    </div>
+  );
+}
+
+function StdErrContent({ content }: Pick<STDERRContentType, "content">) {
+  return (
+    <div className={styles.stdinContainer}>
+      <Prompt />
+      <span className={styles.stdin}>{content}</span>
+    </div>
+  );
+}
+
+function toTerminalContentComponent(
+  { type, content }: TerminalContentType,
+  index: number
+) {
+  const Content = contentMap[type];
+  return <Content key={[type, index].join("-")} content={content} />;
+}

--- a/packages/frontend/src/components/terminal/TerminalContent.tsx
+++ b/packages/frontend/src/components/terminal/TerminalContent.tsx
@@ -1,19 +1,11 @@
+import type { TerminalContentType } from "../../types/terminalType";
+
 import Prompt from "./Prompt";
 import * as styles from "./Terminal.css";
 
 interface TerminalContentProps {
   contentArray: TerminalContentType[];
 }
-
-type TerminalContentType =
-  | STDINContentType
-  | STDOUTContentType
-  | STDERRContentType;
-
-type STDContentType<T> = { type: T; content: string };
-type STDINContentType = STDContentType<"stdin">;
-type STDOUTContentType = STDContentType<"stdout">;
-type STDERRContentType = STDContentType<"stderr">;
 
 export default function TerminalContent({
   contentArray,
@@ -23,12 +15,15 @@ export default function TerminalContent({
 }
 
 const contentMap = {
-  stdin: StdInContent,
-  stdout: StdOutContent,
-  stderr: StdErrContent,
+  stdin: StandardInputContent,
+  stdout: StandardOutputContent,
 };
 
-function StdInContent({ content }: Pick<STDINContentType, "content">) {
+interface ContentProps {
+  content: string;
+}
+
+function StandardInputContent({ content }: ContentProps) {
   return (
     <div className={styles.stdinContainer}>
       <Prompt />
@@ -37,7 +32,7 @@ function StdInContent({ content }: Pick<STDINContentType, "content">) {
   );
 }
 
-function StdOutContent({ content }: Pick<STDOUTContentType, "content">) {
+function StandardOutputContent({ content }: ContentProps) {
   return (
     <div>
       <span>{content}</span>
@@ -45,18 +40,9 @@ function StdOutContent({ content }: Pick<STDOUTContentType, "content">) {
   );
 }
 
-function StdErrContent({ content }: Pick<STDERRContentType, "content">) {
-  return (
-    <div className={styles.stdinContainer}>
-      <Prompt />
-      <span className={styles.stdin}>{content}</span>
-    </div>
-  );
-}
-
 function toTerminalContentComponent(
   { type, content }: TerminalContentType,
-  index: number
+  index: number,
 ) {
   const Content = contentMap[type];
   return <Content key={[type, index].join("-")} content={content} />;

--- a/packages/frontend/src/components/terminal/index.ts
+++ b/packages/frontend/src/components/terminal/index.ts
@@ -1,0 +1,1 @@
+export { default as Terminal } from "./Terminal";

--- a/packages/frontend/src/constants/index.ts
+++ b/packages/frontend/src/constants/index.ts
@@ -1,1 +1,2 @@
 export const ESC_KEY_CODE = "Escape";
+export const ENTER_KEY_CODE = "Enter";

--- a/packages/frontend/src/constants/index.ts
+++ b/packages/frontend/src/constants/index.ts
@@ -1,2 +1,2 @@
-export const ESC_KEY_CODE = "Escape";
-export const ENTER_KEY_CODE = "Enter";
+export const ESC_KEY = "Escape";
+export const ENTER_KEY = "Enter";

--- a/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
+++ b/packages/frontend/src/design-system/components/common/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { IoCloseOutline } from "react-icons/io5";
 
-import { ESC_KEY_CODE } from "../../../../constants";
+import { ESC_KEY } from "../../../../constants";
 import { preventBubbling } from "../../../../utils/event";
 import IconButton from "../IconButton/IconButton";
 
@@ -23,7 +23,7 @@ export default function Modal({ onClose, children }: ModalProps) {
   useEffect(() => {
     setMounted(true);
     const escKeyCloseEvent = (event: KeyboardEvent) => {
-      if (event.key === ESC_KEY_CODE) {
+      if (event.key === ESC_KEY) {
         onClose();
       }
     };

--- a/packages/frontend/src/types/terminalType.ts
+++ b/packages/frontend/src/types/terminalType.ts
@@ -1,0 +1,6 @@
+export type TerminalContentType = StandardInputType | StandardOutputType;
+
+export type StandardInputType = WithContentType<"stdin">;
+export type StandardOutputType = WithContentType<"stdout">;
+
+type WithContentType<T> = { type: T; content: string };

--- a/packages/frontend/src/utils/scroll.ts
+++ b/packages/frontend/src/utils/scroll.ts
@@ -1,0 +1,10 @@
+import { RefObject } from "react";
+
+export function scrollIntoView<T extends Element>(ref: RefObject<T>) {
+  const $element = ref.current;
+  if (!$element) {
+    return;
+  }
+
+  $element.scrollIntoView();
+}


### PR DESCRIPTION
close #69

## ✅ 작업 내용
- Terminal 구현

## 📸 스크린샷
- body 태그 내 flex 스타일 없애고 테스트했습니다!
![terminal](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/e248d685-07cd-4341-9b62-2072da58ba29)

## 📌 이슈 사항
- Prompt 컴포넌트를 제거하고 `::before` 가상 선택자로 '$'를 추가해 봤는데 아래 처럼 커서가 $ 이전에 위치합니다. 나중에 Prompt 컴포넌트 제거를 다시 한 번 시도해 보겠습니다..!
![terminal before](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/0a9f7b7f-e06e-4486-9a07-0642f970d146)
- 테스트 커밋([7ce18c9](https://github.com/boostcampwm2023/web01-GitChallenge/pull/92/commits/7ce18c91237bde737add63e0eacc97e49db223c2))이 포함되어 있습니다. 머지 전에 제거해야 합니다!

## 🟢 완료 조건
- Terminal 에 입력할 수 있다.
- Terminal 에 입력값과 응답값이 기록된다.
- Terminal 내용이 세로 영역보다 길어지면 스크롤 처리된다.

## ✍ 궁금한 점
- 없습니다! 