### PR TITLE
[BE] feat#59 swagger 최초 도입

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,6 +31,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/mongoose": "^10.0.2",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.1.16",
     "@nestjs/typeorm": "^10.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/packages/backend/src/app.controller.ts
+++ b/packages/backend/src/app.controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
+  // @Get()
+  // getHello(): string {
+  //   return this.appService.getHello();
+  // }
 }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -1,10 +1,23 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.use(cookieParser());
+
+  const config = new DocumentBuilder()
+    .setTitle("Merge Masters' Git Challenge API")
+    .setDescription('Git Challenge의 API 설명서입니다! 파이팅!')
+    .setVersion('1.0')
+    .addTag('quizzes')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(8080);
 }
 bootstrap();

--- a/packages/backend/src/quizzes/dto/command-request.dto.ts
+++ b/packages/backend/src/quizzes/dto/command-request.dto.ts
@@ -1,3 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CommandRequestDto {
+  @ApiProperty({ description: '실행할 명령문', example: 'git branch' })
   command: string;
 }

--- a/packages/backend/src/quizzes/dto/command-response.dto.ts
+++ b/packages/backend/src/quizzes/dto/command-response.dto.ts
@@ -1,5 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CommandResponseDto {
+  @ApiProperty({
+    description: '실행한 stdout/stderr 결과',
+    example: '* main\n',
+  })
   message: string;
+
+  @ApiProperty({
+    description: '실행 결과 요약(stdout => success, stderr => fail, vi)',
+    example: 'success',
+  })
   result: 'success' | 'fail' | 'vi';
+
+  @ApiProperty({
+    description: 'git 그래프 상황(아직 미구현)',
+    example: '아직 미구현이에요',
+  })
   graph?: string;
 }

--- a/packages/backend/src/quizzes/dto/quiz.dto.ts
+++ b/packages/backend/src/quizzes/dto/quiz.dto.ts
@@ -1,19 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, IsArray } from 'class-validator';
 
 export class QuizDto {
+  @ApiProperty({ description: '문제 ID', example: 3 })
   @IsInt()
   readonly id: number;
 
   @IsString()
+  @ApiProperty({ description: '문제 제목', example: 'git add & git status' })
   readonly title: string;
 
   @IsString()
+  @ApiProperty({
+    description: '문제 내용',
+    example:
+      '현재 변경된 파일 중에서 `achitecture.md` 파일을 제외하고 staging 해주세요.',
+  })
   readonly description: string;
 
   @IsArray()
   @IsString({ each: true })
+  @ApiProperty({ description: '문제 핵심 키워드', example: ['add', 'status'] })
   readonly keywords: string[];
 
   @IsString()
+  @ApiProperty({ description: '문제 카테고리', example: 'Git Start' })
   readonly category: string;
 }

--- a/packages/backend/src/quizzes/dto/quizzes.dto.ts
+++ b/packages/backend/src/quizzes/dto/quizzes.dto.ts
@@ -1,4 +1,5 @@
 // problem.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsInt, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -27,5 +28,23 @@ export class QuizzesDto {
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => CategoryQuizzesDto)
+  @ApiProperty({
+    description: '문제 제목 리스트',
+    example: [
+      {
+        id: 1,
+        category: 'Git Start',
+        quizzes: [
+          { id: 3, title: 'git add & git status' },
+          { id: 1, title: 'git init' },
+        ],
+      },
+      {
+        id: 2,
+        category: 'Git Advanced',
+        quizzes: [{ id: 4, title: 'git commit --amend' }],
+      },
+    ],
+  })
   categories: CategoryQuizzesDto[];
 }

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -9,6 +9,13 @@ import {
   Res,
   Req,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { QuizDto } from './dto/quiz.dto';
 import { QuizzesService } from './quizzes.service';
 import { QuizzesDto } from './dto/quizzes.dto';
@@ -18,6 +25,7 @@ import { SessionService } from '../session/session.service';
 import { Request, Response } from 'express';
 import { ContainersService } from '../containers/containers.service';
 
+@ApiTags('quizzes')
 @Controller('api/v1/quizzes')
 export class QuizzesController {
   constructor(
@@ -27,6 +35,13 @@ export class QuizzesController {
   ) {}
 
   @Get(':id')
+  @ApiOperation({ summary: 'ID를 통해 문제 정보를 가져올 수 있습니다.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the quiz details',
+    type: QuizDto,
+  })
+  @ApiParam({ name: 'id', description: '문제 ID' })
   async getProblemById(@Param('id') id: number): Promise<QuizDto> {
     const quizDto = await this.quizService.getQuizById(id);
 
@@ -34,11 +49,27 @@ export class QuizzesController {
   }
 
   @Get('/')
+  @ApiOperation({
+    summary: '카테고리 별로 모든 문제의 제목과 id를 가져올 수 있습니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '카테고리 별로 문제의 제목과 id가 리턴됩니다.',
+    type: QuizzesDto,
+  })
   async getProblemsGroupedByCategory(): Promise<QuizzesDto> {
     return this.quizService.findAllProblemsGroupedByCategory();
   }
 
   @Post(':id/command')
+  @ApiOperation({ summary: 'Git 명령을 실행합니다.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Git 명령의 실행 결과(stdout/stderr)를 리턴합니다.',
+    type: CommandResponseDto,
+  })
+  @ApiParam({ name: 'id', description: '문제 ID' })
+  @ApiBody({ description: 'Command to be executed', type: CommandRequestDto })
   async runGitCommand(
     @Param('id') id: number,
     @Body() execCommandDto: CommandRequestDto,
@@ -82,7 +113,7 @@ export class QuizzesController {
         execCommandDto.command,
       );
 
-      response.send({
+      response.status(HttpStatus.OK).send({
         message,
         result,
         // graph: 필요한 경우 여기에 추가

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/mapped-types@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@nestjs/mapped-types@npm:2.0.3"
+  peerDependencies:
+    "@nestjs/common": ^8.0.0 || ^9.0.0 || ^10.0.0
+    class-transformer: ^0.4.0 || ^0.5.0
+    class-validator: ^0.13.0 || ^0.14.0
+    reflect-metadata: ^0.1.12
+  peerDependenciesMeta:
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: 575d530683664a753d389fcdd5c1c770744efc3797051aa8585ed1b02862796fbf14fe9f2b017a1e3c6c47c94287c45f79ff94d2b05294fb65139373506dd257
+  languageName: node
+  linkType: hard
+
 "@nestjs/mongoose@npm:^10.0.2":
   version: 10.0.2
   resolution: "@nestjs/mongoose@npm:10.0.2"
@@ -1069,6 +1086,33 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.2"
   checksum: d63962581826025e41c9c66874ecc788cf19f7df35c6ba943c46d11a929896516b9b365b6387e9c071138b592a4172628207b63bbd684e6d8f9ec97cff4af1e9
+  languageName: node
+  linkType: hard
+
+"@nestjs/swagger@npm:^7.1.16":
+  version: 7.1.16
+  resolution: "@nestjs/swagger@npm:7.1.16"
+  dependencies:
+    "@nestjs/mapped-types": "npm:2.0.3"
+    js-yaml: "npm:4.1.0"
+    lodash: "npm:4.17.21"
+    path-to-regexp: "npm:3.2.0"
+    swagger-ui-dist: "npm:5.9.1"
+  peerDependencies:
+    "@fastify/static": ^6.0.0
+    "@nestjs/common": ^9.0.0 || ^10.0.0
+    "@nestjs/core": ^9.0.0 || ^10.0.0
+    class-transformer: "*"
+    class-validator: "*"
+    reflect-metadata: ^0.1.12
+  peerDependenciesMeta:
+    "@fastify/static":
+      optional: true
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: 09b318985943d0b50dc44f26c2fb094674bfa2d5de9743102e4b2cdeeb16349a5cface6e747fb7eae8c00c98b0da2ae09718de78ebe455947992b0b3c768f09b
   languageName: node
   linkType: hard
 
@@ -2329,6 +2373,7 @@ __metadata:
     "@nestjs/mongoose": "npm:^10.0.2"
     "@nestjs/platform-express": "npm:^10.0.0"
     "@nestjs/schematics": "npm:^10.0.0"
+    "@nestjs/swagger": "npm:^7.1.16"
     "@nestjs/testing": "npm:^10.0.0"
     "@nestjs/typeorm": "npm:^10.0.1"
     "@types/cookie-parser": "npm:^1"
@@ -5413,6 +5458,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
@@ -5422,17 +5478,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
   languageName: node
   linkType: hard
 
@@ -7717,6 +7762,13 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
+  languageName: node
+  linkType: hard
+
+"swagger-ui-dist@npm:5.9.1":
+  version: 5.9.1
+  resolution: "swagger-ui-dist@npm:5.9.1"
+  checksum: dee9f8b9e21b95a659ce3ecc63c71b11e1e4353b972772057a0ad88aa7a1a26eadab82996ef021b71bb8d6a4cc0212fd2fe45e5f72f4ffc57dd4df39993a1c1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #59 

## ✅ 작업 내용

- swagger 모듈 설치 (@nestjs/swagger)
- swagger에 잡히기 때문에 기존 '/' 요청 비활성화(Hello World 이제 안 나옴)
- 현재 모든 DTO, API에 대해 설명 작성
- 실행하면서 진짜 똑같은지 손으로 몇 번 테스트도 해 봤어요...
- POST 시 세션이 생성돼서 그런지 아니면 기본값이 201인지 모르지만 nestjs가 201을 응답하는데, 우리의 동작 상 200 OK가 더 정확하다고 생각해서 (혹은 세션 생성 시 201로 분기 처리?) 일단 200으로 명시했습니다. 이 부분 적극적으로 의견 주셔도 좋아요.
*참고로 /api 루트로 swagger 접속 가능합니다.

## 📸 스크린샷

![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/bd96066e-d6c1-4a66-be07-daf271e75fdb)
이런 느낌입니다.

## 📌 이슈 사항

- swagger 처음 해 봐서 이렇게 데코레이터 주렁주렁 다는게 맞는지 모르겠는데, 일단 GPT는 괜찮다고 합니다.

## 🟢 완료 조건

- swagger 접속 가능
- swagger에 DTO 묘사
- swagger에 API 묘사

## ✍ 궁금한 점

- 앞으로는 API 만들면 swagger까지 붙여서 push 하는거 어떨까요? 너무 당연한 말인가요?