### PR TITLE
[BE] feat#68 세션&문제 별 컨테이너 ID 조회(없으면 생성) 한 뒤 해당 컨테이너에 command 실행 구현

### DIFF
--- a/packages/backend/src/session/schema/session.schema.ts
+++ b/packages/backend/src/session/schema/session.schema.ts
@@ -22,7 +22,7 @@ export class Session extends Document {
     },
   })
   problems: Map<
-    string,
+    number,
     {
       status: string;
       logs: string[];

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -18,7 +18,7 @@ export class SessionService {
       problems: {},
     });
     return await session.save().then((session) => {
-      console.log('session created');
+      console.log(`session ${session._id as ObjectId} created`);
       return (session._id as ObjectId).toString('hex');
     });
   }
@@ -29,17 +29,21 @@ export class SessionService {
   ): Promise<string> {
     const session = await this.getSessionById(sessionId);
 
-    if (!session.problems[problemId]) {
-      session.problems.set(problemId.toString(), {
+    if (!session.problems.get(problemId)) {
+      session.problems.set(problemId, {
         status: 'solving',
         logs: [],
         containerId: '',
       });
-      console.log('session updated');
-      console.log(session.problems[problemId]);
+      console.log(`session ${session._id as ObjectId} updated`);
+      console.log(`session's new quizId: ${problemId}, document created`);
       await session.save();
+    } else {
+      console.log(
+        `containerId: ${session.problems.get(problemId)?.containerId}`,
+      );
     }
-    return session.problems[problemId]?.containerId;
+    return session.problems.get(problemId)?.containerId;
   }
 
   async setContainerBySessionId(
@@ -48,10 +52,11 @@ export class SessionService {
     containerId: string,
   ): Promise<void> {
     const session = await this.getSessionById(sessionId);
-    if (!session.problems.get(problemId.toString())) {
+    if (!session.problems.get(problemId)) {
       throw new Error('problem not found');
     }
-    session.problems.get(problemId.toString()).containerId = containerId;
+    console.log(`setting ${sessionId}'s containerId as ${containerId}`);
+    session.problems.get(problemId).containerId = containerId;
     session.save();
   }
 


### PR DESCRIPTION
close #68

## ✅ 작업 내용

- 컨테이너 존재 여부 검증 로직 작성
- 세션 ID와 문제 번호로 컨테이너 ID 조회 로직 수정
- 스키마 문제 ID를 number로 수정
- 기존 `살려야함` 코드 살리기
- 기타 로그 작성

## 📌 이슈 사항

- 로거 슬슬 도입해야 할까요...?

## 🟢 완료 조건

- 세션이 없으면 세션이 DB에 생성됨
- 컨테이너가 없으면 해당 문제의 컨테이너가 컨테이너 서버에 생성됨, DB에 해당 문제 삽입
- 이후 해당 컨테이너에 POST body로 전달된 command 실행
- 결과 리턴

## ✍ 궁금한 점

- 없습니다!