### PR TITLE
[BE] feat#71 user command 기록 추가

### DIFF
--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -117,6 +117,12 @@ export class QuizzesController {
         execCommandDto.command,
       );
 
+      this.sessionService.pushLogBySessionId(
+        execCommandDto.command,
+        sessionId,
+        id,
+      );
+
       response.status(HttpStatus.OK).send({
         message,
         result,

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -60,6 +60,19 @@ export class SessionService {
     session.save();
   }
 
+  async pushLogBySessionId(
+    command: string,
+    sessionId: string,
+    problemId: number,
+  ): Promise<void> {
+    const session = await this.getSessionById(sessionId);
+    if (!session.problems.get(problemId)) {
+      throw new Error('problem not found');
+    }
+    session.problems.get(problemId).logs.push(command);
+    session.save();
+  }
+
   private async getSessionById(id: string): Promise<Session> {
     return await this.sessionModel.findById(id);
   }


### PR DESCRIPTION
[#71]

close #71 

## ✅ 작업 내용
- session에 유저 입력 기록을 추가한다.

## 📸 스크린샷(FE만)
<img width="673" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/d87bb560-e416-454e-8f59-7049ca11975e">

## 📌 이슈 사항
없습니다!

## 🟢 완료 조건
- user가 comman를 입력했을때 session에 기록된다.

## ✍ 궁금한 점
- 바로 이어서 문제 초기화 delete 바로 구현 가능할 것 같아요