### PR TITLE
[BE] feat#11 문제 초기화시 기록과 컨테이너 삭제 기능 구현

### DIFF
--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -107,4 +107,16 @@ export class ContainersService {
 
     return stdoutData.trim() !== '';
   }
+
+  async deleteContainer(containerId: string): Promise<void> {
+    const command = `docker rm -f ${containerId}`;
+
+    const { stdoutData, stderrData } = await this.executeSSHCommand(command);
+
+    console.log(`container deleted : ${stdoutData}`);
+
+    if (stderrData) {
+      throw new Error(stderrData);
+    }
+  }
 }

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -175,9 +175,9 @@ export class QuizzesController {
         return;
       }
 
-      await this.containerService.deleteContainer(containerId);
+      this.containerService.deleteContainer(containerId);
 
-      await this.sessionService.deleteCommandHistory(sessionId, id);
+      this.sessionService.deleteCommandHistory(sessionId, id);
     } catch (e) {
       throw new HttpException(
         {

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -155,7 +155,6 @@ export class QuizzesController {
       'session에 저장된 command 기록과 컨테이너를 삭제하고, 실제 컨테이너도 삭제 합니다',
   })
   @ApiParam({ name: 'id', description: '문제 ID' })
-  @ApiBody({ required: false })
   async deleteCommandHistory(
     @Param('id') id: number,
     @Req() request: Request,

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -84,6 +84,19 @@ export class SessionService {
     session.save();
   }
 
+  async deleteCommandHistory(
+    sessionId: string,
+    problemId: number,
+  ): Promise<void> {
+    const session = await this.getSessionById(sessionId);
+    if (!session.problems.get(problemId)) {
+      throw new Error('problem not found');
+    }
+    session.problems.get(problemId).logs = [];
+    session.problems.get(problemId).containerId = '';
+    session.save();
+  }
+
   private async getSessionById(id: string): Promise<Session> {
     return await this.sessionModel.findById(id);
   }


### PR DESCRIPTION
close #11 

## ✅ 작업 내용
- DELETE /quizzes/:id/command 컨트롤러에 추가
- container service 컨테이너 삭제 로직 구현
- session service 세션에 기록과 컨테이너 id 삭제하는 로직 구현

## 📌 이슈 사항
- 이후 docker orphan prune 명령을 시행 할 시기를 정해요
- swagger 동작 명시 여부..?

## 🟢 완료 조건
- DELETE /quizzes/:id/command 요청시 세션의 기록과 컨테이너id, 실제 컨테이너가 종료된다

## ✍ 궁금한 점
