### PR TITLE
[FE] style#75 데모용 퀴즈 페이지 스타일링

### DIFF
--- a/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
+++ b/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
@@ -17,6 +17,11 @@ export const description = style([
     color: color.$scale.grey700,
     overflowY: "auto",
     whiteSpace: "break-spaces",
+    "@media": {
+      "(min-width: 1920px) and (max-width: 2559px)": {
+        height: "330px",
+      },
+    },
   },
 ]);
 

--- a/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
+++ b/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
@@ -12,7 +12,7 @@ export const description = style([
   typography.$semantic.body2Regular,
   {
     marginTop: 10,
-    height: 250,
+    height: 60,
     padding: "0 8px 4px 0",
     color: color.$scale.grey700,
     overflowY: "auto",

--- a/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
+++ b/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
@@ -4,16 +4,16 @@ import color from "../../../design-system/tokens/color";
 import typography from "../../../design-system/tokens/typography";
 
 export const strong = style([
-  typography.$semantic.title1Bold,
+  typography.$semantic.title3Bold,
   { color: color.$scale.grey800 },
 ]);
 
 export const description = style([
-  typography.$semantic.body1Regular,
+  typography.$semantic.body2Regular,
   {
-    height: 264,
-    marginTop: 15,
-    padding: "4px 8px 4px 0",
+    marginTop: 10,
+    height: 250,
+    padding: "0 8px 4px 0",
     color: color.$scale.grey700,
     overflowY: "auto",
     whiteSpace: "break-spaces",

--- a/packages/frontend/src/components/quiz/QuizLocation/QuizLocation.css.ts
+++ b/packages/frontend/src/components/quiz/QuizLocation/QuizLocation.css.ts
@@ -10,7 +10,7 @@ export const list = style([
   {
     justifyContent: "flex-start",
     alignItems: "center",
-    marginBottom: 15,
+    marginBottom: 7,
     color: color.$scale.grey700,
   },
 ]);

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -7,7 +7,7 @@ import { flexAlignCenter } from "../../design-system/tokens/utils.css";
 const hrHeight = "20px";
 
 export const container = style({
-  height: 250,
+  height: 170,
   width: "100%",
 });
 

--- a/packages/frontend/src/design-system/components/common/Button/Button.css.ts
+++ b/packages/frontend/src/design-system/components/common/Button/Button.css.ts
@@ -4,12 +4,12 @@ import color from "../../../tokens/color";
 import typography from "../../../tokens/typography";
 
 export const buttonBase = style([
-  typography.$semantic.title3Regular,
+  typography.$semantic.title4Regular,
   {
-    height: 45,
+    height: 42,
     border: "1px solid transparent",
     borderRadius: 8,
-    padding: "11px 22px",
+    padding: "8px 13px",
 
     ":disabled": {
       borderColor: color.$semantic.bgDisabled,

--- a/packages/frontend/src/design-system/components/common/Layout/Layout.tsx
+++ b/packages/frontend/src/design-system/components/common/Layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 
 import * as layout from "../../../tokens/layout.css";
-import { Footer, Header, SideBar } from "../index";
+import { Header, SideBar } from "../index";
 
 interface LayoutProps {
   children: ReactElement;
@@ -14,7 +14,6 @@ export default function Layout({ children }: LayoutProps) {
         <SideBar />
         <div className={layout.container}>{children}</div>
       </div>
-      <Footer />
     </>
   );
 }

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
@@ -10,7 +10,7 @@ export default function SideBar() {
   return (
     <nav className={layout.sideBar}>
       {sidebarNavigation.map((item) => (
-        <Accordion key={item.title}>
+        <Accordion key={item.title} open>
           <Accordion.Details>
             <Accordion.Summary>{item.title}</Accordion.Summary>
             <SubItems subItems={item.subItems} />

--- a/packages/frontend/src/design-system/styles/global.css
+++ b/packages/frontend/src/design-system/styles/global.css
@@ -251,7 +251,7 @@
 .mm-semantic-typography-body2-regular {
   font-size: var(--mm-scale-font-size-100);
   font-weight: var(--mm-static-font-weight-regular);
-  line-height: var(--mm-static-line-height-small);
+  line-height: var(--mm-static-line-height-medium);
   letter-spacing: var(--mm-static-letter-spacing-medium);
 }
 

--- a/packages/frontend/src/mocks/apis/data/quizContentData.ts
+++ b/packages/frontend/src/mocks/apis/data/quizContentData.ts
@@ -1,25 +1,7 @@
 const quizContentMockData = {
   id: 3,
   title: "git add & git status",
-  description: `당신은 새로운 팀에 배정되었습니다. 이제부터 전임자의 일을 이어서 진행해야 합니다. 
-배정된 팀의 저장소 전략은 다음과 같습니다. 
-
-1. 원본 저장소 \`upstream\`이 있다. 
-2. 우리 팀에서 \`upstream\`으로부터 fork한 저장소인 \`origin\`이 있다. 
-3. \`origin\`에서 branch를 생성하여 작업한다. 
-4. 당신은 \`origin\`으로 push할 수 있으며, 필요에 따라 \`upstream\`으로 PR을 생성할 수 있다. 
-
-\`origin\` 저장소 github 주소: https://github.com/flydog98/git-challenge-remote-upstream.git
-
-당신은 새로운 팀에 배정되었습니다. 이제부터 전임자의 일을 이어서 진행해야 합니다. 
-배정된 팀의 저장소 전략은 다음과 같습니다. 
-
-1. 원본 저장소 \`upstream\`이 있다. 
-2. 우리 팀에서 \`upstream\`으로부터 fork한 저장소인 \`origin\`이 있다. 
-3. \`origin\`에서 branch를 생성하여 작업한다. 
-4. 당신은 \`origin\`으로 push할 수 있으며, 필요에 따라 \`upstream\`으로 PR을 생성할 수 있다. 
-
-\`origin\` 저장소 github 주소: https://github.com/flydog98/git-challenge-remote-upstream.git`,
+  description: `현재 디렉터리의 Git 저장소 환경에서 user name과 user email을 여러분의 name과 email로 설정해주세요.`,
   keywords: ["add", "status"],
   category: "Git Start",
 };

--- a/packages/frontend/src/pages/demo.css.ts
+++ b/packages/frontend/src/pages/demo.css.ts
@@ -26,8 +26,13 @@ export const gitGraph = style({
 export const quizContentContainer = style({
   position: "relative",
   width: "50%",
-  height: "410px",
+  height: "400px",
   padding: containerPadding,
+  "@media": {
+    "(min-width: 1920px) and (max-width: 2559px)": {
+      height: "500px",
+    },
+  },
 });
 
 export const commandAccordion = style({

--- a/packages/frontend/src/pages/demo.css.ts
+++ b/packages/frontend/src/pages/demo.css.ts
@@ -3,8 +3,7 @@ import { style } from "@vanilla-extract/css";
 import color from "../design-system/tokens/color";
 import { border } from "../design-system/tokens/utils.css";
 
-const paddingRight = "36px";
-const paddingBottom = "30px";
+const containerPadding = 23;
 
 export const main = style({
   marginBottom: "54px",
@@ -14,7 +13,7 @@ export const mainInner = style([
   border.all,
   {
     borderTop: 0,
-    marginBottom: "25px",
+    marginBottom: "17px",
   },
 ]);
 
@@ -27,18 +26,18 @@ export const gitGraph = style({
 export const quizContentContainer = style({
   position: "relative",
   width: "50%",
-  height: "545px",
-  padding: `42px ${paddingRight} ${paddingBottom}`,
+  height: "410px",
+  padding: containerPadding,
 });
 
 export const commandAccordion = style({
-  marginTop: "15px",
+  marginTop: "12px",
 });
 
 export const checkAnswerButton = style({
   position: "absolute",
-  right: paddingRight,
-  bottom: paddingBottom,
+  right: containerPadding,
+  bottom: containerPadding,
 });
 
 export const submitButton = style({

--- a/packages/frontend/src/pages/demo.css.ts
+++ b/packages/frontend/src/pages/demo.css.ts
@@ -1,0 +1,46 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../design-system/tokens/color";
+import { border } from "../design-system/tokens/utils.css";
+
+const paddingRight = "36px";
+const paddingBottom = "30px";
+
+export const main = style({
+  marginBottom: "54px",
+});
+
+export const mainInner = style([
+  border.all,
+  {
+    borderTop: 0,
+    marginBottom: "25px",
+  },
+]);
+
+export const gitGraph = style({
+  width: "50%",
+  borderRight: `1px solid ${color.$semantic.border}`,
+  textAlign: "center",
+});
+
+export const quizContentContainer = style({
+  position: "relative",
+  width: "50%",
+  height: "545px",
+  padding: `42px ${paddingRight} ${paddingBottom}`,
+});
+
+export const commandAccordion = style({
+  marginTop: "15px",
+});
+
+export const checkAnswerButton = style({
+  position: "absolute",
+  right: paddingRight,
+  bottom: paddingBottom,
+});
+
+export const submitButton = style({
+  textAlign: "end",
+});

--- a/packages/frontend/src/pages/demo.tsx
+++ b/packages/frontend/src/pages/demo.tsx
@@ -47,7 +47,7 @@ export default function QuizPage() {
       </div>
 
       <div className={styles.submitButton}>
-        <Button variant="primaryFill">제출하기</Button>
+        <Button variant="primaryFill">제출 후 채점하기</Button>
       </div>
     </main>
   );

--- a/packages/frontend/src/pages/demo.tsx
+++ b/packages/frontend/src/pages/demo.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+import { CommandAccordion, QuizContent } from "../components/quiz";
+import { Terminal } from "../components/terminal";
+import { Button } from "../design-system/components/common";
+import { flex } from "../design-system/tokens/utils.css";
+import quizContentMockData from "../mocks/apis/data/quizContentData";
+import { TerminalContentType } from "../types/terminalType";
+
+import * as styles from "./demo.css";
+
+const { category, title, description, keywords } = quizContentMockData;
+
+export default function QuizPage() {
+  const [contentArray, setContentArray] = useState<TerminalContentType[]>([]);
+
+  const handleTerminal = (input: string) => {
+    setContentArray([
+      ...contentArray,
+      { type: "stdin", content: input },
+      { type: "stdout", content: "응답값" },
+    ]);
+  };
+
+  return (
+    <main className={styles.main}>
+      <div className={styles.mainInner}>
+        <div className={flex}>
+          <div className={styles.gitGraph} />
+
+          <div className={styles.quizContentContainer}>
+            <QuizContent
+              category={category}
+              title={title}
+              description={description}
+            />
+            <div className={styles.commandAccordion}>
+              <CommandAccordion items={keywords} />
+            </div>
+            <div className={styles.checkAnswerButton}>
+              <Button variant="secondaryFill">모범 답안 확인하기</Button>
+            </div>
+          </div>
+        </div>
+
+        <Terminal contentArray={contentArray} onTerminal={handleTerminal} />
+      </div>
+
+      <div className={styles.submitButton}>
+        <Button variant="primaryFill">제출하기</Button>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
close #75 

## ✅ 작업 내용
- 3주차 데모용 퀴즈 페이지 스타일링

## 📸 스크린샷
- 아래는 모니터에서 촬영했습니다.
![demo](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/0dca6bdc-1f71-440b-9e4b-6c4030d2a3bb)
- 아래는 노트북에서 보이는 화면입니다.
<img width="1552" alt="스크린샷 2023-11-23 오전 12 31 47" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/ede0b411-fbd8-4f50-9b0d-1239881ecea9">

## 📌 이슈 사항
- Terminal 컴포넌트에서 터미널 내용이 변경될 때마다 `scrollIntoView`를 하고 있는데, 페이지에서 보니까 동작이 부자연스러워서 빼는 게 좋아 보입니다..!
- 제 모니터에서는 문제 제출하기 버튼이 짤리는데, 노트북에서는 터미널부터 짤립니다..!
- base layout 스타일에 `height: 100vh` 때문에 아래처럼 레이아웃이 깨지는 문제가 있습니다. 임시로 `minHeight: 100vh`로 변경했는데, 이렇게 하면 사이드바에는 고정된 `height`값이 없어 스크롤 처리가 안 됩니다..어떻게 해결하면 좋을까요🥹
<img width="1381" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/13ec4eda-078c-4855-b5c3-8b442a46a759">


## 🟢 완료 조건
- 디자인 명세에 맞게 스타일링한다. 
- /demo 페이지로 만든다.

## ✍ 궁금한 점
- 이슈 상황과 동일합니다.