### PR TITLE
[FE] feat#118 문제 페이지를 SSG 방식으로 렌더링한다.

### DIFF
--- a/packages/frontend/src/apis/quizzes.ts
+++ b/packages/frontend/src/apis/quizzes.ts
@@ -1,5 +1,5 @@
 import { API_PATH } from "../constants/path";
-import { Command, Quiz } from "../types/quiz";
+import { Categories, Command, Quiz } from "../types/quiz";
 
 import { instance } from "./base";
 
@@ -11,8 +11,12 @@ export const quizAPI = {
     );
     return data;
   },
-  getQuiz: async (id: string) => {
+  getQuiz: async (id: number) => {
     const { data } = await instance.get<Quiz>(`${API_PATH.QUIZZES}/${id}`);
+    return data;
+  },
+  getCategories: async () => {
+    const { data } = await instance.get<Categories>(API_PATH.QUIZZES);
     return data;
   },
 };

--- a/packages/frontend/src/apis/quizzes.ts
+++ b/packages/frontend/src/apis/quizzes.ts
@@ -1,19 +1,23 @@
 import { API_PATH } from "../constants/path";
-import { Command } from "../types/command";
+import { Command, Quiz } from "../types/quiz";
 
 import { instance } from "./base";
 
-export const requestCommand = async ({
-  id,
-  command,
-}: {
+export const quizAPI = {
+  postCommand: async ({ id, command }: PostCommandRequest) => {
+    const { data } = await instance.post<Command>(
+      `${API_PATH.QUIZZES}/${id}/command`,
+      { command },
+    );
+    return data;
+  },
+  getQuiz: async (id: string) => {
+    const { data } = await instance.get<Quiz>(`${API_PATH.QUIZZES}/${id}`);
+    return data;
+  },
+};
+
+type PostCommandRequest = {
   id: number;
   command: string;
-}) => {
-  const { data } = await instance.post<Command>(
-    `${API_PATH.QUIZZES}/${id}/command`,
-    { command },
-  );
-
-  return data;
 };

--- a/packages/frontend/src/components/demo/Demo.tsx
+++ b/packages/frontend/src/components/demo/Demo.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { requestCommand } from "../../apis/quizzes";
+import { quizAPI } from "../../apis/quizzes";
 import { Button } from "../../design-system/components/common";
 import { flex } from "../../design-system/tokens/utils.css";
 import quizContentMockData from "../../mocks/apis/data/quizContentData";
@@ -16,7 +16,7 @@ export default function Demo() {
   const [contentArray, setContentArray] = useState<TerminalContentType[]>([]);
 
   const handleTerminal = async (input: string) => {
-    const data = await requestCommand({
+    const data = await quizAPI.postCommand({
       id: 1,
       command: input,
     });
@@ -32,7 +32,6 @@ export default function Demo() {
       <div className={styles.mainInner}>
         <div className={flex}>
           <div className={styles.gitGraph} />
-
           <div className={styles.quizContentContainer}>
             <QuizContent
               category={category}
@@ -47,10 +46,8 @@ export default function Demo() {
             </div>
           </div>
         </div>
-
         <Terminal contentArray={contentArray} onTerminal={handleTerminal} />
       </div>
-
       <div className={styles.submitButton}>
         <Button variant="primaryFill">제출 후 채점하기</Button>
       </div>

--- a/packages/frontend/src/pages/quizzes/[id].tsx
+++ b/packages/frontend/src/pages/quizzes/[id].tsx
@@ -1,0 +1,71 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { quizAPI } from "../../apis/quizzes";
+import * as styles from "../../components/demo/Demo.css";
+import { CommandAccordion, QuizContent } from "../../components/quiz";
+import { Terminal } from "../../components/terminal";
+import { Button } from "../../design-system/components/common";
+import { flex } from "../../design-system/tokens/utils.css";
+import { Quiz } from "../../types/quiz";
+import { TerminalContentType } from "../../types/terminalType";
+import { isString } from "../../utils/typeGuard";
+
+export default function QuizPage() {
+  const [contentArray, setContentArray] = useState<TerminalContentType[]>([]);
+  const [quiz, setQuiz] = useState<Quiz | null>(null);
+  const {
+    query: { id },
+  } = useRouter();
+
+  useEffect(() => {
+    if (!isString(id)) {
+      return;
+    }
+
+    quizAPI.getQuiz(id).then((data) => setQuiz(data));
+  }, [id]);
+  const handleTerminal = async (input: string) => {
+    if (!isString(id)) {
+      return;
+    }
+
+    const data = await quizAPI.postCommand({
+      id: +id,
+      command: input,
+    });
+    setContentArray([
+      ...contentArray,
+      { type: "stdin", content: input },
+      { type: "stdout", content: data.message },
+    ]);
+  };
+
+  if (!quiz) return null;
+  return (
+    <main className={styles.main}>
+      <div className={styles.mainInner}>
+        <div className={flex}>
+          <div className={styles.gitGraph} />
+          <div className={styles.quizContentContainer}>
+            <QuizContent
+              category={quiz.category}
+              title={quiz.title}
+              description={quiz.description}
+            />
+            <div className={styles.commandAccordion}>
+              <CommandAccordion items={quiz.keywords} />
+            </div>
+            <div className={styles.checkAnswerButton}>
+              <Button variant="secondaryFill">모범 답안 확인하기</Button>
+            </div>
+          </div>
+        </div>
+        <Terminal contentArray={contentArray} onTerminal={handleTerminal} />
+      </div>
+      <div className={styles.submitButton}>
+        <Button variant="primaryFill">제출 후 채점하기</Button>
+      </div>
+    </main>
+  );
+}

--- a/packages/frontend/src/types/quiz.ts
+++ b/packages/frontend/src/types/quiz.ts
@@ -7,3 +7,11 @@ export type Command = {
   result: CommandSuccess | CommandFail | CommandVI;
   graph?: string;
 };
+
+export type Quiz = {
+  id: number;
+  title: string;
+  description: string;
+  keywords: string[];
+  category: string;
+};

--- a/packages/frontend/src/types/quiz.ts
+++ b/packages/frontend/src/types/quiz.ts
@@ -15,3 +15,16 @@ export type Quiz = {
   keywords: string[];
   category: string;
 };
+
+export type Quizzes = {
+  id: number;
+  category: string;
+  quizzes: {
+    id: number;
+    title: string;
+  }[];
+}[];
+
+export type Categories = {
+  categories: Quizzes;
+};


### PR DESCRIPTION
close #118 

## ✅ 작업 내용
- 페어 프로그래밍 했읍니당 ✌🏻
- CSR로 우선 구현 후 getStaticPath 사용해 SSG 렌더링으로 변경 후 비교

## 📸 스크린샷(FE만)

## 📌 이슈 사항
없습니다!

## 🟢 완료 조건
- SSG로 퀴즈 페이지가 빌드 시에 만들어진다.

![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/c5d62366-1d08-45d2-bcc4-04139aeac449)

## ✍ 궁금한 점
없습니다!
