### PR TITLE
[FE] hotfix#121 목차 데이터 최신화, 문제 페이지 스타일링

### DIFF
--- a/packages/frontend/src/components/quiz/CommandAccordion/CommandAccordion.tsx
+++ b/packages/frontend/src/components/quiz/CommandAccordion/CommandAccordion.tsx
@@ -6,12 +6,16 @@ import {
 import badgeGroupLayout from "./CommandAccordion.css";
 
 interface CommandAccordionProps {
+  width?: number | string;
   items: string[];
 }
 
-export default function CommandAccordion({ items }: CommandAccordionProps) {
+export default function CommandAccordion({
+  width = "100%",
+  items,
+}: CommandAccordionProps) {
   return (
-    <Accordion>
+    <Accordion width={width}>
       <Accordion.Details>
         <Accordion.Summary color="grey" size="sm">
           {({ open }) => <>핵심명령어 {open ? "숨기기" : "보기"}</>}

--- a/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
+++ b/packages/frontend/src/components/quiz/QuizContent/QuizContent.css.ts
@@ -19,7 +19,7 @@ export const description = style([
     whiteSpace: "break-spaces",
     "@media": {
       "(min-width: 1920px) and (max-width: 2559px)": {
-        height: "330px",
+        height: 250,
       },
     },
   },

--- a/packages/frontend/src/design-system/components/common/Accordion/Accordion.tsx
+++ b/packages/frontend/src/design-system/components/common/Accordion/Accordion.tsx
@@ -5,7 +5,7 @@ import AccordionDetails from "./AccordionDetails";
 import AccordionSummary from "./AccordionSummary";
 
 interface AccordionProps {
-  width?: number;
+  width?: number | string;
   open?: boolean;
   children: ReactNode;
 }

--- a/packages/frontend/src/design-system/components/common/Accordion/AccordionContextProvider.tsx
+++ b/packages/frontend/src/design-system/components/common/Accordion/AccordionContextProvider.tsx
@@ -10,7 +10,7 @@ import {
 
 export type AccordionContextType = {
   open: boolean;
-  width: number;
+  width: number | string;
   onChange: (open: boolean) => void;
 };
 
@@ -27,7 +27,7 @@ export function AccordionContextProvider({
   children,
 }: {
   open: boolean;
-  width: number;
+  width: number | string;
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(initOpen);
@@ -36,12 +36,12 @@ export function AccordionContextProvider({
     (nextOpen: boolean) => {
       setOpen(nextOpen);
     },
-    [setOpen]
+    [setOpen],
   );
 
   const accordionContextValue = useMemo(
     () => ({ open, onChange: handleChange, width }),
-    [open, handleChange, width]
+    [open, handleChange, width],
   );
 
   useEffect(() => {

--- a/packages/frontend/src/design-system/components/common/SideBar/nav.ts
+++ b/packages/frontend/src/design-system/components/common/SideBar/nav.ts
@@ -1,12 +1,12 @@
 export const gitHelpNavigation = {
-  title: "$ git help",
+  title: "$ Git Help",
   subTitle: "명령어 이해하기",
 };
 
 export const sidebarNavigation = [
   {
     id: 1,
-    title: "git start",
+    title: "Git Start",
     subItems: [
       {
         id: 1,
@@ -21,50 +21,80 @@ export const sidebarNavigation = [
         subTitle: "파일 스테이징 하기",
       },
       {
-        id: 991,
+        id: 4,
         subTitle: "커밋하기",
       },
       {
-        id: 992,
+        id: 5,
         subTitle: "브랜치 만들기",
       },
       {
-        id: 993,
+        id: 6,
         subTitle: "브랜치 바꾸기",
       },
     ],
   },
   {
-    id: "2",
-    title: "git advanced",
+    id: 2,
+    title: "Git Advanced",
     subItems: [
       {
-        id: 4,
+        id: 7,
         subTitle: "커밋 메시지 수정하기",
       },
       {
-        id: 994,
-        subTitle: "커밋 되돌리기",
+        id: 8,
+        subTitle: "커밋 취소하기",
       },
       {
-        id: 995,
-        subTitle: "변경 사항 지우기",
+        id: 9,
+        subTitle: "파일 되돌리기",
       },
       {
-        id: 996,
-        subTitle: "변경 사항 저9장하기",
+        id: 10,
+        subTitle: "파일 삭제하기",
       },
       {
-        id: 997,
+        id: 11,
+        subTitle: "변경 사항 저장하기",
+      },
+      {
+        id: 12,
         subTitle: "커밋 가져오기",
       },
       {
-        id: 998,
+        id: 13,
         subTitle: "커밋 이력 조작하기",
       },
       {
-        id: 999,
+        id: 14,
         subTitle: "변경 사항 되돌리기",
+      },
+    ],
+  },
+  {
+    id: 3,
+    title: "Remote Start",
+    subItems: [
+      {
+        id: 15,
+        subTitle: "원격 저장소 등록하기",
+      },
+      {
+        id: 16,
+        subTitle: "브랜치 생성하고 이동하기",
+      },
+      {
+        id: 17,
+        subTitle: "브랜치 최신화하기",
+      },
+      {
+        id: 18,
+        subTitle: "원격 저장소로 보내기",
+      },
+      {
+        id: 19,
+        subTitle: "브랜치 삭제하기",
       },
     ],
   },

--- a/packages/frontend/src/pages/quizzes/[id].tsx
+++ b/packages/frontend/src/pages/quizzes/[id].tsx
@@ -48,7 +48,7 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
               description={quiz.description}
             />
             <div className={styles.commandAccordion}>
-              <CommandAccordion items={quiz.keywords} />
+              <CommandAccordion width="100%" items={quiz.keywords} />
             </div>
             <div className={styles.checkAnswerButton}>
               <Button variant="secondaryFill">모범 답안 확인하기</Button>


### PR DESCRIPTION
close #121

## ✅ 작업 내용
- 목차 데이터 최신화 및 오타 수정
- 문제 페이지 스타일링 수정

## 📸 스크린샷
- 스타일링 수정 
  - 미디어쿼리 1920 ~ 2559 시 핵심 명령어와 모범 답안 확인하기 충돌
  - 핵심 명령어가 아코디언 width보다 커질 때 뱃지 글자 줄바꿈

|AS-IS|TO-BE|
|-|-|
|<img width="1331" alt="스크린샷 2023-11-24 오전 8 48 18" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/54ca8c30-0a67-4331-b243-06851b2b0fa1">|<img width="1342" alt="스크린샷 2023-11-24 오전 8 49 58" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/5c0066c8-8331-49ac-a4b6-47879295122a">|

## 📌 이슈 사항
- 목차 데이터는 임시로 한글화했습니다!
- 목차 데이터는 한글이지만, 문제 조회 API 에서는 영어이기 때문에 문제 페이지에서 "Git Advanced > git cherry-pick" 식으로 나옵니다.

## 🟢 완료 조건
- 목차 데이터를 서버 데이터와 동기화한다.
- 스타일링 깨지는 곳을 수정한다.

## ✍ 궁금한 점
- 없습니다!