### PR TITLE
[BE] 제공되는 터미널 환경에서는 네트워크가 불능해야한다 

### DIFF
--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -82,7 +82,7 @@ export class ContainersService {
       'CONTAINER_SSH_USERNAME',
     );
 
-    const createContainerCommand = `docker run -itd mergemasters/alpine-git:0.1 /bin/sh`;
+    const createContainerCommand = `docker run --network none -itd mergemasters/alpine-git:0.1 /bin/sh`;
     const { stdoutData } = await this.executeSSHCommand(createContainerCommand);
     const containerId = stdoutData.trim();
 


### PR DESCRIPTION
[#123]

close #123 

## ✅ 작업 내용
- docker container는 네트워크가 불능해야한다

## 📸 스크린샷
```bash
root@****:~# docker exec -it f6a191153cc4 /bin/sh
/ # ping www.google.com
^C
root@****:~# docker inspect f6a191153cc4
#...
"Networks": {
                "none": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": null,
                    "NetworkID": "****",
                    "EndpointID": "****",
                    "Gateway": "",
                    "IPAddress": "",
                    "IPPrefixLen": 0,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "",
                    "DriverOpts": null
                }
            }
#...
```

## 📌 이슈 사항
- 피어세션에서 데모 링크 보내줬을때 누가 바로 clone 명령 시도하는거 보고 도입했습니다

## 🟢 완료 조건
- docker container는 네트워크가 불능해야한다

## ✍ 궁금한 점
도커 명령어로 네트워크 차단했습니다.
알파인 리눅스 내부의 설정을 건드릴까 하다가, 도커로 설정하는게 관리측면에서 이점을 가질 것 같아 이렇게 해결했는데 괜찮을까요?