### PR TITLE
[BE] feat#125 Guard를 설정한다

### DIFF
--- a/packages/backend/src/command.guard.ts
+++ b/packages/backend/src/command.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommandGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const command = request.body['command'];
+    return typeof command === 'string' && command.startsWith('git');
+  }
+}

--- a/packages/backend/src/session/session.decorator.ts
+++ b/packages/backend/src/session/session.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const SessionId = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.cookies['sessionId'];
+  },
+);

--- a/packages/backend/src/session/session.guard.ts
+++ b/packages/backend/src/session/session.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+/**
+ * @description session guard
+ * @returns {boolean}
+ * check if sessionId exists
+ * @dependency cookie-parser
+ */
+@Injectable()
+export class SessionGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    // cookie-parser must be used before this guard
+    return request['cookies'].sessionId;
+  }
+}


### PR DESCRIPTION
- SessionGuard add
- CommandGuard add

[#125]

close #125 

## ✅ 작업 내용
- SessionGuard 추가
  - Session이 없으면 통과하지 못합니다
- CommandGuard 추가
  - 우선, git으로만 시작하는 명령만 통과할 수 있도록 하였습니다 
## 📸 스크린샷
git으로 시작하지 않는 명령어는 거절됩니다
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/e4c8d265-e56d-4283-ac3c-8eb1fdeb2742)

세션id가 없을 경우 delete요청은 guard로 부터 거절됩니다
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/723d7c3b-daa1-44c1-9237-65a566c074c0)


## 📌 이슈 사항
- SessionGuard에서 SessionId가 없음녀 추가해주는 로직도 넣어주려 하였으나, SessionId가 없을때 생성해야할 필요가 있는 api가 POST /quizzes/:id/command 밖에 없고, DELETE는 SessionId가 없을면 만들 필요도 없다는것을 확인했습니다.
- 앞으로 DELETE, 뿐만 아니라 채점 등등 로직이 추가될때 필요한 기능이 세션 없을시 할당이 아닌 세션 없을시 실행도 안하도록 하면 될 것 같아 그렇게 설정했습니다.
- 앞으로는 매개변수로 sessionID를 받아올 수 있도록 설정했습니다.
- CommandGuard는 앞으로 명령어가 정상적으로 예상대로 들어왔는지 판단하기 위한 Guard입니다. 우선적으로 git 명령어만 허용하기로 하여 git이 아닌 명령이 들어오지 않도록만 하였고, Guard에서 이 역할을 수행하는게 자연스러울 것 같아 추가해봤습니다

## 🟢 완료 조건
- Guard가 동작한다

## ✍ 궁금한 점
- 이상하거나 도입이 부자연스럽다고 느껴지는것은 바로바로 말씀해주세요!
- 용준님의 logger 선 도입으로 제가 수월하게 log 도입이 가능했어서 Guard를 선 도입하고 쉽게 추가 도입할 수 있도록 시도해봤습니다