### PR TITLE
[FE] hotfix#132 다른 문제로 이동할 때 터미널 초기화되지 않는 문제 해결

### DIFF
--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -40,6 +40,7 @@ export const commandInputContainer = style([
   {
     width: "100%",
     position: "relative",
+    paddingLeft: 6,
   },
 ]);
 

--- a/packages/frontend/src/pages/quizzes/[id].tsx
+++ b/packages/frontend/src/pages/quizzes/[id].tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { quizAPI } from "../../apis/quizzes";
 import * as styles from "../../components/demo/Demo.css";
@@ -18,6 +18,10 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
   const {
     query: { id },
   } = useRouter();
+
+  useEffect(() => {
+    setContentArray([]);
+  }, [id]);
 
   const handleTerminal = async (input: string) => {
     if (!isString(id)) {


### PR DESCRIPTION
close #132 

## ✅ 작업 내용
- 문제 페이지 이동 시 터미널 초기화 되도록 수정
- 터미널 css 수정

## 📸 스크린샷(FE만)
@LuizyHub 터미널 여백 만들어 드렸어요😊🙏
<img width="294" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/8fccb94b-6e32-4b44-8b09-f1bea5a65f2c">


## 📌 이슈 사항
없습니다!

## 🟢 완료 조건
터미널이 초기화되어야 한다.

## ✍ 궁금한 점
없습니다!
