### PR TITLE
[BE]feat#167 파이프, 세미콜론, 부등호 등의 커맨드 체이닝을 방지한다

### DIFF
--- a/packages/backend/src/common/command.guard.ts
+++ b/packages/backend/src/common/command.guard.ts
@@ -9,7 +9,13 @@ export class CommandGuard implements CanActivate {
     return (
       typeof mode === 'string' &&
       typeof message === 'string' &&
-      (mode === 'editor' || (mode === 'command' && message.startsWith('git')))
+      (mode === 'editor' ||
+        (mode === 'command' &&
+          message.startsWith('git') &&
+          !this.isMessageIncluded(message, [';', '>', '|', '<'])))
     );
+  }
+  private isMessageIncluded(message: string, keywords: string[]): boolean {
+    return keywords.some((keyword) => message.includes(keyword));
   }
 }

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -29,7 +29,7 @@ import { Response } from 'express';
 import { ContainersService } from '../containers/containers.service';
 import { SessionId } from '../session/session.decorator';
 import { SessionGuard } from '../session/session.guard';
-import { CommandGuard } from '../command.guard';
+import { CommandGuard } from '../common/command.guard';
 import { QuizWizardService } from '../quiz-wizard/quiz-wizard.service';
 import { Fail, SubmitDto, Success } from './dto/submit.dto';
 


### PR DESCRIPTION
close #167 

## ✅ 작업 내용
- [';', '>', '|', '<'] block
- 디렉토리 common으로 이동

## 📌 이슈 사항

## 🟢 완료 조건
- ';', '>', '|', '<' 가 포함된 명령은 차단된다

## ✍ 궁금한 점
- 백엔드 방어로직이 보강되기 전까지 입력에서 차단하는게 좋다고 생각합니다