### PR TITLE
[BE] feat#172 session log 스키마 수정

### DIFF
--- a/packages/backend/src/session/schema/session.schema.ts
+++ b/packages/backend/src/session/schema/session.schema.ts
@@ -1,14 +1,15 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
+const Action = {
+  Command: 'command',
+  Editor: 'editor',
+} as const;
+
+export type ActionType = (typeof Action)[keyof typeof Action];
+
 @Schema({ timestamps: true })
 export class Session extends Document {
-  // @Prop({ required: true })
-  // createdAt: Date;
-  //
-  // @Prop({ required: true })
-  // updatedAt: Date;
-
   @Prop()
   deletedAt: Date | null;
 
@@ -17,7 +18,15 @@ export class Session extends Document {
     type: Map,
     of: {
       status: { type: String, required: true },
-      logs: { type: [String], required: true },
+      logs: {
+        type: [
+          {
+            mode: { type: String, enum: Object.values(Action), required: true },
+            message: { type: String, required: true },
+          },
+        ],
+        required: true,
+      },
       containerId: { type: String, default: '' },
     },
   })
@@ -25,7 +34,10 @@ export class Session extends Document {
     number,
     {
       status: string;
-      logs: string[];
+      logs: {
+        mode: ActionType;
+        message: string;
+      }[];
       containerId: string;
     }
   >;

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Logger } from 'winston';
 import { Model } from 'mongoose';
-import { Session } from './schema/session.schema';
+import { ActionType, Session } from './schema/session.schema';
 import { ObjectId } from 'typeorm';
 
 @Injectable()
@@ -71,7 +71,10 @@ export class SessionService {
     session.save();
   }
 
-  async getRecentLog(sessionId: string, problemId: number): Promise<string> {
+  async getRecentLog(
+    sessionId: string,
+    problemId: number,
+  ): Promise<{ mode: string; message: string }> {
     const session = await this.getSessionById(sessionId);
 
     const problemLogs = session?.problems.get(problemId)?.logs;
@@ -83,7 +86,7 @@ export class SessionService {
   }
 
   async pushLogBySessionId(
-    command: string,
+    log: { mode: ActionType; message: string },
     sessionId: string,
     problemId: number,
   ): Promise<void> {
@@ -91,7 +94,7 @@ export class SessionService {
     if (!session.problems.get(problemId)) {
       throw new Error('problem not found');
     }
-    session.problems.get(problemId).logs.push(command);
+    session.problems.get(problemId).logs.push(log);
     session.save();
   }
 


### PR DESCRIPTION
[#172]

close #172 

## ✅ 작업 내용
- session log 스키마 변경
- 최긘 log 조회 함수 변경
- log 삽입 함수 변경

## 📸 스크린샷(BE도)
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/39eb34ca-8af2-469f-83e7-fbb82574fb70)
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/e725b7ab-b9c9-4a30-aa27-8493b29403bc)

## 📌 이슈 사항
- merge하면 바로 데이터베이스 날려주세요!
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/104267255/d26d488b-3b38-485e-a544-a25ec3ff3e79)

## 🟢 완료 조건
- 새로운 스키마에 맞는 log가 잘 적용된다

## ✍ 궁금한 점
