### PR TITLE
[BE] fix#177 DB 컨테이너 ID 초기화 로직 삭제

### DIFF
--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -37,7 +37,7 @@ export class SessionService {
       session.problems.set(problemId, {
         status: 'solving',
         logs: [],
-        containerId: 'default-id',
+        containerId: '',
       });
       this.logger.log('info', `session ${session._id as ObjectId} updated`);
       this.logger.log(


### PR DESCRIPTION
close #177 

## ✅ 작업 내용

- 분명히 없앴는데, 아까 SSH Pool 작업하면서 슬쩍 깃 꼬인 거 놓쳤나봐요 ㅠㅠ

## 📌 이슈 사항

- 초기화 로직 너무 아쉽네요.

## 🟢 완료 조건

- default id로 초기화하지 않고 ''으로 초기화한다.

## ✍ 궁금한 점

- 없습니다.