### PR TITLE
[FE] feat#10 문제 초기화 API 연결 (작업 완료!)

### DIFF
--- a/packages/frontend/src/apis/quiz.ts
+++ b/packages/frontend/src/apis/quiz.ts
@@ -25,6 +25,10 @@ export const quizAPI = {
     );
     return data;
   },
+  resetQuizById: async (id: number) => {
+    const { data } = await instance.delete(`${API_PATH.QUIZZES}/${id}/command`);
+    return data;
+  },
 };
 
 type PostCommandRequest = {

--- a/packages/frontend/src/apis/quiz.ts
+++ b/packages/frontend/src/apis/quiz.ts
@@ -4,10 +4,10 @@ import { Categories, Command, Quiz, QuizSolve } from "../types/quiz";
 import { instance } from "./base";
 
 export const quizAPI = {
-  postCommand: async ({ id, command }: PostCommandRequest) => {
+  postCommand: async ({ id, mode, message }: PostCommandRequest) => {
     const { data } = await instance.post<Command>(
       `${API_PATH.QUIZZES}/${id}/command`,
-      { command },
+      { mode, message },
     );
     return data;
   },
@@ -33,5 +33,6 @@ export const quizAPI = {
 
 type PostCommandRequest = {
   id: number;
-  command: string;
+  mode: "command" | "editor";
+  message: string;
 };

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -1,8 +1,7 @@
-import { type KeyboardEventHandler, useEffect, useRef } from "react";
+import { type KeyboardEventHandler, forwardRef } from "react";
 
 import { ENTER_KEY } from "../../constants/event";
 import type { TerminalContentType } from "../../types/terminalType";
-import { scrollIntoView } from "../../utils/scroll";
 
 import CommandInput from "./CommandInput";
 import * as styles from "./Terminal.css";
@@ -10,42 +9,40 @@ import TerminalContent from "./TerminalContent";
 
 interface TerminalProps {
   contentArray: TerminalContentType[];
-  onTerminal: (input: string) => Promise<void>;
+  onTerminal: (input: string) => void;
 }
 
-export default function Terminal({ contentArray, onTerminal }: TerminalProps) {
-  const inputRef = useRef<HTMLSpanElement>(null);
+const Terminal = forwardRef<HTMLSpanElement, TerminalProps>(
+  ({ contentArray, onTerminal }, ref) => {
+    const handleStandardInput: KeyboardEventHandler = async (event) => {
+      const { key, currentTarget } = event;
+      if (key !== ENTER_KEY) {
+        return;
+      }
 
-  const handleStandardInput: KeyboardEventHandler = async (event) => {
-    const { key, currentTarget } = event;
-    if (key !== ENTER_KEY) {
-      return;
-    }
+      event.preventDefault();
 
-    event.preventDefault();
+      const value = (currentTarget.textContent ?? "").trim();
+      if (!value) {
+        return;
+      }
 
-    const value = (currentTarget.textContent ?? "").trim();
-    if (!value) {
-      return;
-    }
+      onTerminal(value);
+    };
 
-    await onTerminal(value);
+    return (
+      <div className={styles.container}>
+        <div className={styles.hr} />
+        <div className={styles.terminalContainer}>
+          <TerminalContent contentArray={contentArray} />
 
-    currentTarget.textContent = "";
-  };
-
-  useEffect(() => {
-    scrollIntoView(inputRef);
-  }, [contentArray]);
-
-  return (
-    <div className={styles.container}>
-      <div className={styles.hr} />
-      <div className={styles.terminalContainer}>
-        <TerminalContent contentArray={contentArray} />
-
-        <CommandInput handleInput={handleStandardInput} ref={inputRef} />
+          <CommandInput handleInput={handleStandardInput} ref={ref} />
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);
+
+Terminal.displayName = "Terminal";
+
+export default Terminal;

--- a/packages/frontend/src/mocks/apis/quizHandlers.ts
+++ b/packages/frontend/src/mocks/apis/quizHandlers.ts
@@ -20,4 +20,21 @@ export const quizHandlers = [
 
     return res(ctx.json({ solved: true, link: "mock-share-link" }));
   }),
+  rest.delete(`${quizPath}/:id/command`, (req, res, ctx) => {
+    const { id } = req.params;
+    if (!isString(id)) {
+      return res(ctx.status(404));
+    }
+
+    const idNum = parseInt(id, 10);
+    if (idNum < 1 || idNum > 19) {
+      return res(ctx.status(404));
+    }
+
+    if (idNum === 1) {
+      return res(ctx.status(500));
+    }
+
+    return res();
+  }),
 ];

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -30,7 +30,8 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
 
     const data = await quizAPI.postCommand({
       id: +id,
-      command: input,
+      mode: "command",
+      message: input,
     });
     setContentArray([
       ...contentArray,

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { quizAPI } from "../../apis/quiz";
 import { QuizGuide } from "../../components/quiz/QuizGuide";
 import { Terminal } from "../../components/terminal";
-import { Button } from "../../design-system/components/common";
+import { Button, toast } from "../../design-system/components/common";
 import { Categories, Quiz } from "../../types/quiz";
 import { TerminalContentType } from "../../types/terminalType";
 import { isString } from "../../utils/typeGuard";
@@ -39,6 +39,21 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
     ]);
   };
 
+  const handleReset = async () => {
+    if (!isString(id)) {
+      return;
+    }
+
+    try {
+      await quizAPI.resetQuizById(+id);
+      toast.success("문제가 성공적으로 초기화되었습니다!");
+    } catch (error) {
+      toast.error(
+        "문제 초기화 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+      );
+    }
+  };
+
   if (!quiz) return null;
   return (
     <main className={styles.mainContainer}>
@@ -48,7 +63,9 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
       </div>
       <Terminal contentArray={contentArray} onTerminal={handleTerminal} />
       <div className={styles.buttonGroup}>
-        <Button variant="secondaryLine">문제 다시 풀기</Button>
+        <Button variant="secondaryLine" onClick={handleReset}>
+          문제 다시 풀기
+        </Button>
         <Button variant="primaryFill">제출 후 채점하기</Button>
       </div>
     </main>

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -60,6 +60,7 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
 
   useEffect(() => {
     setContentArray([]);
+    clearTextContent(terminalInputRef);
   }, [id]);
 
   useEffect(() => {

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -47,7 +47,10 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
         <QuizGuide quiz={quiz} />
       </div>
       <Terminal contentArray={contentArray} onTerminal={handleTerminal} />
-      <Button variant="primaryFill">제출 후 채점하기</Button>
+      <div className={styles.buttonGroup}>
+        <Button variant="secondaryLine">문제 다시 풀기</Button>
+        <Button variant="primaryFill">제출 후 채점하기</Button>
+      </div>
     </main>
   );
 }

--- a/packages/frontend/src/pages/quizzes/quiz.css.ts
+++ b/packages/frontend/src/pages/quizzes/quiz.css.ts
@@ -5,3 +5,10 @@ import { border, flex, widthFull } from "../../design-system/tokens/utils.css";
 export const mainContainer = style([widthFull]);
 
 export const topContainer = style([flex, border.verticalSide]);
+
+export const buttonGroup = style([
+  flex,
+  {
+    justifyContent: "space-between",
+  },
+]);


### PR DESCRIPTION
close #10

## ✅ 작업 내용
- 문제 페이지에 초기화 버튼 추가
- 초기화 API 모킹
  - **에러 테스트를 위해 1번 문제는 500 응답, 그 외에는 200 응답**으로 설정했습니다.
- 초기화 API 연결
- 퀴즈 페이지 이동 시 터미널 입력값이 초기화되지 않는 문제 해결

## 📸 스크린샷
**초기화 성공**

![quiz reset](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/ea12263a-4b63-4c79-afc3-4146699dfaf3)

**초기화 실패 (모킹 API 환경에서 테스트했습니다)**
![quiz reset fail](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/af33344a-6bae-46f7-b7ed-e9b934b516f5)



**퀴즈 페이지 이동 시 터미널 입력값 초기**
![quiz page terminal input reset](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/182d9b43-d82c-4d35-8aab-442652af0093)


## 📌 이슈 사항
- 피그마 디자인을 보면 아래와 같이 되어있지만, Undo 기능은 나중에 추가될 것 같아서 Undo 자리에 Reset 버튼을 뒀습니다.
- 퀴즈 페이지 스타일링이 많이 변경될 것 같아서 임시로 초기화 버튼 스타일 코드도 demo.css.ts에 작성했습니다. 
- API 성공/실패 관련 코드는 나중에 API 인터셉터나 훅을 만들 것 같아서 대충 작성했습니다..😅

## 🟢 완료 조건
- 초기화 성공 시
  - 터미널을 초기화한다.
  - 터미널에 포커싱한다.
  - 토스트 메시지로 사용자에게 안내한다.
- 초기화 실패 시 토스트 메시지로 사용자에게 안내한다.

## ✍ 궁금한 점
- ~~초기화 성공 시 터미널과 편집기를 어떻게 할지 고민입니다..!~~ [회의](https://www.notion.so/11-30-cbf2eacb0323427fa9414e95d436c822?pvs=4#94392e842323416badb0e7afe46284e4)로 결정했습니다!
- `Button` 컴포넌트 레이아웃을 위해 div 태그로 감쌌는데, `Button` 컴포넌트에 `props.className`을 추가해서 바로 레이아웃할 수 있도록 할까 고민 중입니다!