### PR TITLE
[FE] fix#139 Terminal 붙여넣기 버그

### DIFF
--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -1,4 +1,8 @@
-import { type KeyboardEventHandler, forwardRef } from "react";
+import {
+  type ClipboardEventHandler,
+  type KeyboardEventHandler,
+  forwardRef,
+} from "react";
 
 import classnames from "../../utils/classnames";
 
@@ -10,24 +14,43 @@ interface CommandInputProps {
 }
 
 const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
-  ({ handleInput }, ref) => (
-    <div className={styles.commandInputContainer}>
-      <span id="commandLabel" style={{ display: "none" }}>
-        Enter git command
-      </span>
-      <Prompt />
-      <span
-        className={classnames(styles.commandInput, styles.stdin)}
-        contentEditable
-        onKeyDown={handleInput}
-        role="textbox"
-        aria-placeholder="git command"
-        aria-labelledby="commandLabel"
-        tabIndex={0}
-        ref={ref}
-      />
-    </div>
-  )
+  ({ handleInput }, ref) => {
+    const handlePaste: ClipboardEventHandler = (event) => {
+      event.preventDefault();
+
+      const pastedDataPlainText = event.clipboardData.getData("text/plain");
+      const range = document.getSelection()?.getRangeAt(0);
+      if (!range) {
+        return;
+      }
+
+      range.deleteContents();
+
+      const textNode = document.createTextNode(pastedDataPlainText);
+      range.insertNode(textNode);
+      range.collapse(false);
+    };
+
+    return (
+      <div className={styles.commandInputContainer}>
+        <span id="commandLabel" style={{ display: "none" }}>
+          Enter git command
+        </span>
+        <Prompt />
+        <span
+          className={classnames(styles.commandInput, styles.stdin)}
+          contentEditable
+          onKeyDown={handleInput}
+          onPaste={handlePaste}
+          role="textbox"
+          aria-placeholder="git command"
+          aria-labelledby="commandLabel"
+          tabIndex={0}
+          ref={ref}
+        />
+      </div>
+    );
+  },
 );
 
 CommandInput.displayName = "CommandInput";

--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -27,8 +27,14 @@ const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
       range.deleteContents();
 
       const textNode = document.createTextNode(pastedDataPlainText);
+      const cursorAnchorNode = document.createElement("span");
+
+      range.insertNode(cursorAnchorNode);
       range.insertNode(textNode);
       range.collapse(false);
+
+      cursorAnchorNode.scrollIntoView();
+      cursorAnchorNode.remove();
     };
 
     return (

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -59,4 +59,5 @@ export const stdin = style({
 export const commandInput = style({
   flex: 1,
   outline: 0,
+  wordBreak: "break-all",
 });


### PR DESCRIPTION
close #139

## ✅ 작업 내용
- Terminal에 복사/붙여넣을 때
  - 기본 동작을 막고, 플레인 텍스트로 삽입
  - 가로 스크롤 막기
  - 커서가 있는 곳으로 스크롤하기 (CSS로 해결)

## 📸 스크린샷
**복사/붙여넣기 버그**

|AS-IS|TO-BE|
|-|-|
|![terminal paste asis](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/1a93c241-0a22-4ce5-b50f-60d28ffd2da1)|![terminal paste tobe](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/ca4a283b-03c7-46ef-baba-25ae2e58dcf3)|

**붙여넣기 시 커서가 있는 곳으로 스크롤하기**
|AS-IS|TO-BE|
|-|-|
|![terminal cursor asis](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/e44379fd-4752-4ac6-b4a2-91fa7c44b267)|![terminal cursor tobe](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/d71a8eb5-6cc6-4e47-ab7a-3d01f6adb346)|

**붙여넣기 시 가로 스크롤 막기**
|AS-IS|TO-BE|
|-|-|
|![terminal break word](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/4269a6eb-1dc3-4796-acb6-2b668ed3ab85)|![terminal break word after](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/d067df49-9bb6-4e01-ae23-72e24ba42842)|

## 📌 이슈 사항
- 없습니다!

## 🟢 완료 조건
- 복사/붙여넣을 때
  - span 태그가 추가되지 않는다.
  - plain text로 추가된다.
  - 현재 커서가 있는 위치로 스크롤이 이동한다.
- 가로 영역보다 긴 문자열을 복사/붙여넣을 때 가로 스크롤이 되지 않는다.

## ✍ 궁금한 점
- 커서가 잘 안 보이는 것 같습니다! 터미널처럼 커서 두껍게 가야할까요? 

cf. 참고한 글
- [contenteditable 일 때 plain text로 붙여넣기](https://phuoc.ng/collection/html-dom/paste-as-plain-text/)
- [커서가 있는 곳으로 스크롤하기](https://stackoverflow.com/a/67152280)