### PR TITLE
[FE] feat#186 편집기 라인 모드에서 지원하지 않는 명령어 입력 처리

### DIFF
--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -25,6 +25,13 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const toCommandMode = (nextInputValue: string) => {
+    setMode("command");
+    setInputValue(nextInputValue);
+    setInputReadonly(true);
+    textareaRef.current?.focus();
+  };
+
   const handleTextareaOnChange: ChangeEventHandler<HTMLTextAreaElement> = (
     event,
   ) => {
@@ -52,9 +59,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
     const { key } = event;
     if (isInsertMode(mode)) {
       if (key === "Escape") {
-        setMode("command");
-        setInputValue("");
-        setInputReadonly(true);
+        toCommandMode("");
       }
     }
   };
@@ -69,10 +74,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
     const currentFile = textareaRef.current?.value;
 
     if (key === "Escape") {
-      setMode("command");
-      setInputValue("");
-      setInputReadonly(true);
-      textareaRef.current?.focus();
+      toCommandMode("");
       return;
     }
 
@@ -80,11 +82,8 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
       const changedFile = initialFile !== currentFile;
       if (value === ":q") {
         if (changedFile) {
-          setInputValue("E37: No write since last change (add ! to override)");
-          setInputReadonly(true);
-          setMode("command");
           event.preventDefault();
-          textareaRef.current?.focus();
+          toCommandMode("E37: No write since last change (add ! to override)");
           return;
         }
         onSubmit(initialFile);
@@ -103,11 +102,8 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
         return;
       }
 
-      setInputValue(`E492: Not an editor command: ${value.substring(1)}`);
-      setInputReadonly(true);
-      setMode("command");
       event.preventDefault();
-      textareaRef.current?.focus();
+      toCommandMode(`E492: Not an editor command: ${value.substring(1)}`);
     }
   };
 

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -69,8 +69,9 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
   ) => {
     const {
       key,
-      currentTarget: { value },
+      currentTarget: { value: valueBeforeTrim },
     } = event;
+    const value = valueBeforeTrim.trim();
     const currentFile = textareaValue;
 
     if (key === ESC_KEY) {
@@ -80,6 +81,12 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
 
     if (key === ENTER_KEY) {
       const changedFile = initialFile !== currentFile;
+
+      if (value === ":") {
+        toCommandMode(":");
+        return;
+      }
+
       if (value === ":q") {
         if (changedFile) {
           event.preventDefault();

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -7,7 +7,6 @@ import {
 import { FaInfoCircle } from "react-icons/fa";
 
 import { ENTER_KEY, ESC_KEY } from "../../constants/event";
-import { isString } from "../../utils/typeGuard";
 
 import * as styles from "./Editor.css";
 
@@ -72,7 +71,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
       key,
       currentTarget: { value },
     } = event;
-    const currentFile = textareaRef.current?.value;
+    const currentFile = textareaValue;
 
     if (key === ESC_KEY) {
       toCommandMode("");
@@ -97,9 +96,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
       }
 
       if (value === ":wq" || value === ":wq!") {
-        if (isString(currentFile)) {
-          onSubmit(currentFile);
-        }
+        onSubmit(currentFile);
         return;
       }
 

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -6,6 +6,7 @@ import {
 } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 
+import { ENTER_KEY, ESC_KEY } from "../../constants/event";
 import { isString } from "../../utils/typeGuard";
 
 import * as styles from "./Editor.css";
@@ -58,7 +59,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
   const handleTextareaKeyUp: KeyboardEventHandler = (event) => {
     const { key } = event;
     if (isInsertMode(mode)) {
-      if (key === "Escape") {
+      if (key === ESC_KEY) {
         toCommandMode("");
       }
     }
@@ -73,12 +74,12 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
     } = event;
     const currentFile = textareaRef.current?.value;
 
-    if (key === "Escape") {
+    if (key === ESC_KEY) {
       toCommandMode("");
       return;
     }
 
-    if (key === "Enter") {
+    if (key === ENTER_KEY) {
       const changedFile = initialFile !== currentFile;
       if (value === ":q") {
         if (changedFile) {

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -100,7 +100,14 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
         if (isString(currentFile)) {
           onSubmit(currentFile);
         }
+        return;
       }
+
+      setInputValue(`E492: Not an editor command: ${value.substring(1)}`);
+      setInputReadonly(true);
+      setMode("command");
+      event.preventDefault();
+      textareaRef.current?.focus();
     }
   };
 

--- a/packages/frontend/src/components/editor/__tests__/editor.spec.tsx
+++ b/packages/frontend/src/components/editor/__tests__/editor.spec.tsx
@@ -334,6 +334,30 @@ describe("Editor", () => {
     );
   });
 
+  describe("라인 모드에서", () => {
+    it.each([["wwq"], ["w"], ["ㅈㅂ"], ["ㅂ"], ["wq!!"], [":"]])(
+      "지원하지 않는 명령어 %s를 입력하면 에러 메시지가 표시되고 명령 모드로 전환된다.",
+      async (input) => {
+        renderComponent({
+          initialFile: mockInitialFileData,
+          onSubmit: mockSubmitHandler,
+        });
+        const $textarea = screen.getByTestId("textarea");
+        const $input = screen.getByTestId("input");
+
+        await user.type($textarea, ":");
+
+        await user.type($input, input);
+        await user.keyboard("{Enter}");
+
+        expect($input).toHaveValue(`E492: Not an editor command: ${input}`);
+        expect($input).toHaveAttribute("readonly");
+        expect(document.activeElement).toEqual($textarea);
+        expect(mockSubmitHandler).toHaveBeenCalledTimes(0);
+      },
+    );
+  });
+
   describe("라인 모드에서 명령 모드로 전환했을 때", () => {
     it("textarea에 커서가 맞춰진다.", async () => {
       renderComponent({ initialFile: "", onSubmit: mockSubmitHandler });

--- a/packages/frontend/src/components/editor/__tests__/editor.spec.tsx
+++ b/packages/frontend/src/components/editor/__tests__/editor.spec.tsx
@@ -356,6 +356,28 @@ describe("Editor", () => {
         expect(mockSubmitHandler).toHaveBeenCalledTimes(0);
       },
     );
+
+    it.each([[" ", "  "]])(
+      "빈 값을 입력하면 명령 모드로 전환된다.",
+      async (input) => {
+        renderComponent({
+          initialFile: mockInitialFileData,
+          onSubmit: mockSubmitHandler,
+        });
+        const $textarea = screen.getByTestId("textarea");
+        const $input = screen.getByTestId("input");
+
+        await user.type($textarea, ":");
+
+        await user.type($input, input);
+        await user.keyboard("{Enter}");
+
+        expect($input).toHaveValue(":");
+        expect($input).toHaveAttribute("readonly");
+        expect(document.activeElement).toEqual($textarea);
+        expect(mockSubmitHandler).toHaveBeenCalledTimes(0);
+      },
+    );
   });
 
   describe("라인 모드에서 명령 모드로 전환했을 때", () => {


### PR DESCRIPTION
close #186 

## ✅ 작업 내용
- 편집기 라인 모드에서
  - 지원하지 않는 명령어 입력 시 에러 메시지 표시 후 명령 모드로 전환
  - 빈 값 입력 시 명령 모드로 전환 (vi 테스트하다 발견한 기능이라 추가로 구현했습니다)
- 편집기 테스트 코드 작성
- 편집기 일부 리팩토링

## 📸 스크린샷
**테스트 결과**
<img width="399" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/c7c88758-42b4-460c-8687-421c19a50ad6">

**라인 모드에서 지원하지 않은 명령어를 입력**

| vi 실제 동작 | Editor 동작 |
|-|-|
|![vi not command](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/efa03238-45c6-4886-8972-5e0d45d89d0a)|![editor line not eidtor command](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/177ad68a-5c08-42ef-81d4-a39dd75f709f)|

**라인 모드에서 빈 값 입력 시 명령 모드로 전환**

| vi 실제 동작 | Editor 동작 |
|-|-|
|![vi empty command](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/99659f0d-68fd-4be0-8350-200adf28f83b)|![editor empty command](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/103dac7f-d2f2-4c83-8d36-f7860fb4b02f)|


## 📌 이슈 사항
- ctrl + c 단축키 동작이 현재 편접기 모드와 파일 변경 유무에 따라 다릅니다..! ctrl + c는 당장 필요한 기능은 아닌 것 같아서 구현하지 않았습니다. 하지만 당장 필요하다 생각하시면 이슈 만들어서 구현하겠습니다!! 관련 내용은 [노션](https://www.notion.so/11-30-f9f2f0ceeefb48da8db35cf26cbf9c0b)에 정리했습니다.
- 라인 모드에서 빈 값 입력 시 명령 모드로 전환하는 테스트 코드 작성할 때, `user.type($input, "")` 코드가 에러 나서 `""` 값에 대해서는 테스트 코드를 작성하지 못 했습니다. 에러에 대해서 찾아보니 `user.type()`으로 아예 빈 값은 입력할 수 없고, `user.clear()`를 사용하는 것 같습니다.  

## 🟢 완료 조건
- 라인 모드에서 지원하지 않은 명령어를 입력하면 하단에 에러 메시지가 표시되고 명령 모드로 전환된다.
- 편집기 테스트 케이스 모두 통과한다.

## ✍ 궁금한 점
- 편집기 코드에 리팩토링이 필요해 보이지만..일부만 하고 흐린 눈 했습니다..6주차에 이슈로 만들어서 하는 걸로 할까요?