### PR TITLE
[BE] feat#158 8번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -13,6 +13,7 @@ export class QuizWizardService {
     5: (containerId: string) => this.checkCondition5(containerId),
     6: (containerId: string) => this.checkCondition6(containerId),
     7: (containerId: string) => this.checkCondition7(containerId),
+    8: (containerId: string) => this.checkCondition8(containerId),
   };
 
   async submit(containerId: string, quizId: number) {
@@ -91,5 +92,39 @@ index e69de29..3b18e51 100644
     }
 
     return true;
+  }
+
+  async checkCondition8(containerId: string): Promise<boolean> {
+    try {
+      const commitHash = await this.magic.getCommitHashByMessage(
+        containerId,
+        '회원가입 테스트 코드 작성',
+      );
+      if (
+        !commitHash ||
+        (await this.magic.getTreeHead(containerId, commitHash)) !==
+          '3c363aeb69b28b176bf565dba6bb8a3a92d9fd5d'
+      ) {
+        return false;
+      }
+
+      if (
+        (await this.magic.getTreeHead(containerId, `${commitHash}~1`)) !==
+        'eeee188ee95190bf884e106326de84f1051b9ea1'
+      ) {
+        return false;
+      }
+
+      if (
+        (await this.magic.getTreeHead(containerId, `${commitHash}~2`)) !==
+        'bebe52f7d1c8440fb4b1af9aa70ad9523d56336b'
+      ) {
+        return false;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -122,6 +122,17 @@ index e69de29..3b18e51 100644
         return false;
       }
 
+      const commitHashSecond = await this.magic.getCommitHashByMessage(
+        containerId,
+        '회원가입 기능 구현',
+      );
+      if (
+        (await this.magic.getTreeHead(containerId, `${commitHashSecond}`)) !==
+        'eeee188ee95190bf884e106326de84f1051b9ea1'
+      ) {
+        return false;
+      }
+
       return true;
     } catch {
       return false;

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -426,6 +426,199 @@ describe('QuizWizardController (e2e)', () => {
     });
   });
 
+  describe('8번 문제 채점 테스트', () => {
+    const id = 8;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git reset HEAD~1',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "회원가입 기능 구현"',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.test.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "회원가입 테스트 코드 작성"',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('에디터 적극 사용 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git reset HEAD~1',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'editor',
+          message: '회원가입 기능 구현',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.test.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'editor',
+          message: '회원가입 테스트 코드 작성',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('add, commit 순서 반대로', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git reset HEAD~1',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.test.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "회원가입 테스트 코드 작성"',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git add signup.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "회원가입 기능 구현"',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+
+    it('아무 것도 안 하고 채점', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
   afterAll(async () => {
     await app.close();
   });


### PR DESCRIPTION
close #158 

## ✅ 작업 내용

- 8번 문제 채점 테스트 코드 작성
- 8번 문제 채점 로직 작성

## 📌 이슈 사항

- 계획 때는 확실히 하려고 초기 4개를 검사하자고 했는데, 초기 4개부터 내려오는 로직은 매끄럽지 않기 때문에(자식부터 올라가는 포인터가 있는 구조) 커밋 메시지를 기준으로 찾아서 커밋 3개 올라가면서 검증합니다.

## 🟢 완료 조건

- 8번 문제 채점 가능
- 모든 테스트 통과

## ✍ 궁금한 점

- 없습니다!
