### PR TITLE
[BE] feat#159 9번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/quiz-wizard/magic.ts
+++ b/packages/backend/src/quiz-wizard/magic.ts
@@ -58,4 +58,12 @@ export class Magic {
 
     return stdoutData.trim();
   }
+
+  async getHashObject(container: string, filename: string): Promise<string> {
+    const { stdoutData } = await this.sshService.executeSSHCommand(
+      `docker exec -u quizzer -w /home/quizzer/quiz ${container} sh -c "git hash-object ${filename}"`,
+    );
+
+    return stdoutData.trim();
+  }
 }

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -122,17 +122,6 @@ index e69de29..3b18e51 100644
         return false;
       }
 
-      const commitHashSecond = await this.magic.getCommitHashByMessage(
-        containerId,
-        '회원가입 기능 구현',
-      );
-      if (
-        (await this.magic.getTreeHead(containerId, `${commitHashSecond}`)) !==
-        'eeee188ee95190bf884e106326de84f1051b9ea1'
-      ) {
-        return false;
-      }
-
       return true;
     } catch {
       return false;

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -122,6 +122,17 @@ index e69de29..3b18e51 100644
         return false;
       }
 
+      const commitHashSecond = await this.magic.getCommitHashByMessage(
+        containerId,
+        '회원가입 기능 구현',
+      );
+      if (
+        (await this.magic.getTreeHead(containerId, `${commitHashSecond}`)) !==
+        'eeee188ee95190bf884e106326de84f1051b9ea1'
+      ) {
+        return false;
+      }
+
       return true;
     } catch {
       return false;

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -14,6 +14,7 @@ export class QuizWizardService {
     6: (containerId: string) => this.checkCondition6(containerId),
     7: (containerId: string) => this.checkCondition7(containerId),
     8: (containerId: string) => this.checkCondition8(containerId),
+    9: (containerId: string) => this.checkCondition9(containerId),
   };
 
   async submit(containerId: string, quizId: number) {
@@ -59,7 +60,7 @@ index e69de29..3b18e51 100644
   async checkCondition4(containerId: string): Promise<boolean> {
     return (
       (await this.magic.getTreeHead(containerId, 'main')) ===
-      '2c347f65f96ed5817553d668c062f8bec792131d'
+      '2d9c4be41cfcd733671742229782ff0ee390cce3'
     );
   }
 
@@ -137,5 +138,12 @@ index e69de29..3b18e51 100644
     } catch {
       return false;
     }
+  }
+
+  async checkCondition9(containerId: string): Promise<boolean> {
+    return (
+      (await this.magic.getHashObject(containerId, 'important.js')) ===
+      'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
+    );
   }
 }

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -167,10 +167,18 @@ describe('QuizWizardController (e2e)', () => {
         .post(`/api/v1/quizzes/${id}/command`)
         .send({
           mode: 'command',
-          message: 'git commit -m "test commit"',
+          message: 'git add .',
         });
 
       cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "test commit"',
+        });
 
       response = await request(app.getHttpServer())
         .post(`/api/v1/quizzes/${id}/submit`)
@@ -185,10 +193,18 @@ describe('QuizWizardController (e2e)', () => {
         .post(`/api/v1/quizzes/${id}/command`)
         .send({
           mode: 'command',
-          message: 'git commit',
+          message: 'git add .',
         });
 
       cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit',
+        });
 
       response = await request(app.getHttpServer())
         .post(`/api/v1/quizzes/${id}/command`)
@@ -212,6 +228,24 @@ describe('QuizWizardController (e2e)', () => {
         .send({
           mode: 'command',
           message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+
+    it('add하지 않은 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "test commit"',
         });
 
       cookie = response.headers['set-cookie'][0].split(';')[0];
@@ -598,6 +632,51 @@ describe('QuizWizardController (e2e)', () => {
         .expect(200);
 
       expect(response.body).toHaveProperty('solved', false);
+    });
+
+    it('아무 것도 안 하고 채점', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
+  describe('9번 문제 채점 테스트', () => {
+    const id = 9;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git restore important.js',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
     });
 
     it('아무 것도 안 하고 채점', async () => {


### PR DESCRIPTION
close #159 

## ✅ 작업 내용

- 9번 문제 테스트 케이스 설계
  - 해결책이 간단하다 보니 머리의 한계로 케이스가 좀 약한 것 같아요
- 9번 문제 채점 로직 구현
- 4번 문제 더 정확한 버전으로 수정
- 실제 4번 문제 정확한 버전 컨테이너에도 반영

## 📌 이슈 사항

- 없습니다!

## 🟢 완료 조건

- 9번 문제 채점 가능
- 모든 테스트 케이스 통과

## ✍ 궁금한 점

- 없습니다!
