### PR TITLE
[BE] feat#157 10번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/quiz-wizard/magic.ts
+++ b/packages/backend/src/quiz-wizard/magic.ts
@@ -11,7 +11,15 @@ export class Magic {
 
   async isDirectoryExist(container: string, path: string): Promise<boolean> {
     const { stdoutData } = await this.sshService.executeSSHCommand(
-      `docker exec -w /home/quizzer/quiz/ -u quizzer ${container} ls -l ${path} | grep ^d`,
+      `docker exec -w /home/quizzer/quiz/ -u quizzer ${container} ls -la | grep '^d.* ${path}$'`,
+    );
+
+    return stdoutData !== '';
+  }
+
+  async isFileExist(container: string, path: string): Promise<boolean> {
+    const { stdoutData } = await this.sshService.executeSSHCommand(
+      `docker exec -w /home/quizzer/quiz/ -u quizzer ${container} ls | grep '^${path}$'`,
     );
 
     return stdoutData !== '';

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -15,6 +15,7 @@ export class QuizWizardService {
     7: (containerId: string) => this.checkCondition7(containerId),
     8: (containerId: string) => this.checkCondition8(containerId),
     9: (containerId: string) => this.checkCondition9(containerId),
+    10: (containerId: string) => this.checkCondition10(containerId),
   };
 
   async submit(containerId: string, quizId: number) {
@@ -145,5 +146,19 @@ index e69de29..3b18e51 100644
       (await this.magic.getHashObject(containerId, 'important.js')) ===
       'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
     );
+  }
+
+  async checkCondition10(containerId: string): Promise<boolean> {
+    if (await this.magic.isFileExist(containerId, 'tmp.js')) {
+      return false;
+    }
+    if (await this.magic.isFileExist(containerId, 'tmptmp.js')) {
+      return false;
+    }
+    if (await this.magic.isFileExist(containerId, 'tmptmptmp.js')) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -698,6 +698,75 @@ describe('QuizWizardController (e2e)', () => {
     });
   });
 
+  describe('10번 문제 채점 테스트', () => {
+    const id = 10;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git clean -f tmp.js',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git clean -f tmptmp.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git clean -f tmptmptmp.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('tmptmptmp.js는 안 지움', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git clean -f tmp.js',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git clean -f tmptmp.js',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
   afterAll(async () => {
     await app.close();
   });


### PR DESCRIPTION
close #157 

## ✅ 작업 내용

- 10번 문제 테스트 케이스 작성(tmptmptmp.js가 안 지워지는 경우로)
- 10번 문제 채점 로직 구현
- 1번 문제에서 사용하는 isDirectoryExist 버그 수정

## 📌 이슈 사항

- 이전 디렉터리 로직(isDirectoryExist)에서 정규식으로 끝나는 것($문자) 까지 추가하려다가 원하는 대로 동작하지 않는 것 같아서 파일 찾는것과 같은 로직으로 수정했습니다!

## 🟢 완료 조건

- 10번 문제 채점 가능
- 모든 테스트 통과

## ✍ 궁금한 점

- 없습니다!