### PR TITLE
[FE] feat#120 터미널 Resizable Split View 적용

### DIFF
--- a/packages/frontend/src/components/quiz/QuizGuide/QuizGuide.css.ts
+++ b/packages/frontend/src/components/quiz/QuizGuide/QuizGuide.css.ts
@@ -1,12 +1,13 @@
 import { style } from "@vanilla-extract/css";
 
 import color from "../../../design-system/tokens/color";
-import { flexColumn } from "../../../design-system/tokens/utils.css";
+import { baseLayer, flexColumn } from "../../../design-system/tokens/utils.css";
 
 const containerPadding = 23;
 
 export const quizContentContainer = style([
   flexColumn,
+  baseLayer,
   {
     position: "relative",
     width: "50%",

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -2,31 +2,21 @@ import { style } from "@vanilla-extract/css";
 
 import color from "../../design-system/tokens/color";
 import typography from "../../design-system/tokens/typography";
-import { border, flexAlignCenter } from "../../design-system/tokens/utils.css";
-
-const hrHeight = "20px";
-
-export const container = style([
-  typography.$semantic.code,
-  border.all,
-  {
-    height: 180,
-    width: "100%",
-  },
-]);
-
-export const hr = style({
-  height: hrHeight,
-  margin: 0,
-  border: "none",
-  borderBottom: `1px solid ${color.$semantic.border}`,
-  backgroundColor: color.$scale.grey100,
-});
+import {
+  border,
+  flexAlignCenter,
+  middleLayer,
+} from "../../design-system/tokens/utils.css";
+import { barHeight } from "../../pages/quizzes/quiz.css";
 
 export const terminalContainer = style([
-  typography.$semantic.caption1Regular,
+  typography.$semantic.code,
+  middleLayer,
+  border.all,
   {
-    height: `calc(100% - ${hrHeight})`,
+    flex: 1,
+    minHeight: `calc(180px - ${barHeight})`,
+    width: "100%",
     padding: "10px 10px",
     overflowY: "auto",
     color: color.$scale.grey900,

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -7,7 +7,6 @@ import {
   flexAlignCenter,
   middleLayer,
 } from "../../design-system/tokens/utils.css";
-import { barHeight } from "../../pages/quizzes/quiz.css";
 
 export const terminalContainer = style([
   typography.$semantic.code,
@@ -15,7 +14,7 @@ export const terminalContainer = style([
   border.all,
   {
     flex: 1,
-    minHeight: `calc(180px - ${barHeight})`,
+    minHeight: 160,
     width: "100%",
     padding: "10px 10px",
     overflowY: "auto",

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -31,13 +31,9 @@ const Terminal = forwardRef<HTMLSpanElement, TerminalProps>(
     };
 
     return (
-      <div className={styles.container}>
-        <div className={styles.hr} />
-        <div className={styles.terminalContainer}>
-          <TerminalContent contentArray={contentArray} />
-
-          <CommandInput handleInput={handleStandardInput} ref={ref} />
-        </div>
+      <div className={styles.terminalContainer}>
+        <TerminalContent contentArray={contentArray} />
+        <CommandInput handleInput={handleStandardInput} ref={ref} />
       </div>
     );
   },

--- a/packages/frontend/src/design-system/styles/global.css
+++ b/packages/frontend/src/design-system/styles/global.css
@@ -293,5 +293,6 @@
 
 .mm-semantic-typography-code {
   font-family: "Fira Code", monospace;
+  font-size: var(--mm-scale-font-size-75);
   line-height: var(--mm-static-line-height-medium);
 }

--- a/packages/frontend/src/design-system/styles/reset.css
+++ b/packages/frontend/src/design-system/styles/reset.css
@@ -14,10 +14,6 @@ h6,
 p,
 blockquote,
 pre,
-a {
-  color: inherit;
-  text-decoration: none;
-}
 abbr,
 acronym,
 address,
@@ -109,7 +105,10 @@ body {
   font-weight: 400;
   background-color: var(--mm-scale-color-grey-00);
 }
-
+a {
+  color: inherit;
+  text-decoration: none;
+}
 ol,
 ul {
   list-style: none;

--- a/packages/frontend/src/hooks/useResizableSplitView.ts
+++ b/packages/frontend/src/hooks/useResizableSplitView.ts
@@ -1,0 +1,35 @@
+import { MouseEvent, useRef, useState } from "react";
+
+export default function useResizableSplitView() {
+  const barRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
+
+  const [prevBarClientY, setPrevBarClientY] = useState(0);
+  const [prevUpHeight, setPrevUpHeight] = useState(0);
+
+  const handleBarHover = (event: MouseEvent<HTMLDivElement>) => {
+    if (!topRef.current) return;
+    setPrevBarClientY(event.clientY);
+
+    const { height } = topRef.current.getBoundingClientRect();
+    setPrevUpHeight(height);
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
+  const handleMouseMove = ({ clientY }: { clientY: number }) => {
+    if (!topRef.current) {
+      return;
+    }
+    const dClientY = clientY - prevBarClientY;
+    const nextHeight = prevUpHeight + dClientY;
+    topRef.current.style.height = `${Math.max(nextHeight, 0)}px`;
+  };
+
+  const handleMouseUp = () => {
+    document.removeEventListener("mousemove", handleMouseMove);
+    document.removeEventListener("mouseup", handleMouseUp);
+  };
+
+  return { barRef, topRef, handleBarHover };
+}

--- a/packages/frontend/src/hooks/useResizableSplitView.ts
+++ b/packages/frontend/src/hooks/useResizableSplitView.ts
@@ -1,18 +1,17 @@
-import { MouseEvent, useRef, useState } from "react";
+import { MouseEvent, useRef } from "react";
 
 export default function useResizableSplitView() {
   const barRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
-
-  const [prevBarClientY, setPrevBarClientY] = useState(0);
-  const [prevUpHeight, setPrevUpHeight] = useState(0);
+  const prevBarClientY = useRef(0);
+  const prevUpHeight = useRef(0);
 
   const handleBarHover = (event: MouseEvent<HTMLDivElement>) => {
     if (!topRef.current) return;
-    setPrevBarClientY(event.clientY);
+    prevBarClientY.current = event.clientY;
 
     const { height } = topRef.current.getBoundingClientRect();
-    setPrevUpHeight(height);
+    prevUpHeight.current = height;
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseUp);
   };
@@ -21,8 +20,8 @@ export default function useResizableSplitView() {
     if (!topRef.current) {
       return;
     }
-    const dClientY = clientY - prevBarClientY;
-    const nextHeight = prevUpHeight + dClientY;
+    const dClientY = clientY - prevBarClientY.current;
+    const nextHeight = prevUpHeight.current + dClientY;
     topRef.current.style.height = `${Math.max(nextHeight, 0)}px`;
   };
 

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -7,6 +7,7 @@ import { quizAPI } from "../../apis/quiz";
 import { QuizGuide } from "../../components/quiz/QuizGuide";
 import { Terminal } from "../../components/terminal";
 import { Button, toast } from "../../design-system/components/common";
+import useResizableSplitView from "../../hooks/useResizableSplitView";
 import { Categories, Quiz } from "../../types/quiz";
 import { TerminalContentType } from "../../types/terminalType";
 import { scrollIntoView } from "../../utils/scroll";
@@ -67,18 +68,29 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
     scrollIntoView(terminalInputRef);
   }, [contentArray]);
 
+  const { barRef, topRef, handleBarHover } = useResizableSplitView();
   if (!quiz) return null;
   return (
     <main className={styles.mainContainer}>
-      <div className={styles.topContainer}>
-        <div style={{ width: "50%", display: "flex" }}>git graph</div>
-        <QuizGuide quiz={quiz} />
+      <div className={styles.mainInnerContainer}>
+        <div className={styles.topContainer} ref={topRef}>
+          <div style={{ width: "50%", display: "flex" }}>git graph</div>
+          <QuizGuide quiz={quiz} />
+        </div>
+        <div
+          className={styles.bar}
+          role="button"
+          tabIndex={0}
+          ref={barRef}
+          aria-label="divider"
+          onMouseDown={handleBarHover}
+        />
+        <Terminal
+          contentArray={contentArray}
+          onTerminal={handleTerminal}
+          ref={terminalInputRef}
+        />
       </div>
-      <Terminal
-        contentArray={contentArray}
-        onTerminal={handleTerminal}
-        ref={terminalInputRef}
-      />
       <div className={styles.buttonGroup}>
         <Button variant="secondaryLine" onClick={handleReset}>
           문제 다시 풀기

--- a/packages/frontend/src/pages/quizzes/quiz.css.ts
+++ b/packages/frontend/src/pages/quizzes/quiz.css.ts
@@ -1,8 +1,35 @@
 import { style } from "@vanilla-extract/css";
 
-import { border, flex, widthFull } from "../../design-system/tokens/utils.css";
+import color from "../../design-system/tokens/color";
+import {
+  border,
+  flex,
+  flexColumn,
+  middleLayer,
+  widthFull,
+} from "../../design-system/tokens/utils.css";
+
+export const barHeight = "20px";
+
+export const bar = style([
+  middleLayer,
+  border.all,
+  {
+    minHeight: barHeight,
+    borderBottom: "none",
+    backgroundColor: color.$scale.grey100,
+    cursor: "row-resize",
+  },
+]);
 
 export const mainContainer = style([widthFull]);
+export const mainInnerContainer = style([
+  flexColumn,
+  {
+    marginBottom: "17px",
+    height: 580,
+  },
+]);
 
 export const topContainer = style([flex, border.verticalSide]);
 

--- a/packages/frontend/src/pages/quizzes/quiz.css.ts
+++ b/packages/frontend/src/pages/quizzes/quiz.css.ts
@@ -9,13 +9,11 @@ import {
   widthFull,
 } from "../../design-system/tokens/utils.css";
 
-export const barHeight = "20px";
-
 export const bar = style([
   middleLayer,
   border.all,
   {
-    minHeight: barHeight,
+    minHeight: 20,
     borderBottom: "none",
     backgroundColor: color.$scale.grey100,
     cursor: "row-resize",


### PR DESCRIPTION
close #120 

## ✅ 작업 내용
- useResizableSplitView Hook 구현
  - 헤드리스 느낌으로 구현해봤는데 사실 가장 큰 이유는 퀴즈 페이지의 상단 부분과 사이즈 조절 바, 그리고 터미널을 페이지단에서 핸들링해야해서 페이지 단 로직이 너무 커지는 것 같아 분리하게 되었습니다!
- 퀴즈 페이지에 적용

## 📸 스크린샷(FE만)
![Dec-01-2023 01-00-58](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/846d9c92-47d3-48a1-b2d3-8aa97f945938)

## 📌 이슈 사항
- 초반에 스플릿 바에 마우스 다운을 할 때, 높이가 잠깐 뒤틀리는데 왜 초반에만 뒤틀리는지 디버깅해보았는데 해결을 하지 못했습니다... 😭
  - 그 다음부터는 커서가 잘 잡혀요
- 이슈 사항이라고는 뭐하지만 데모 페이지 삭제하고 레이아웃 손 봐야할 것 같습니다! 터미널 리사이징 구현 도중에 해당 태스크(#128)를 처리하기 애매해서 진행하지 않았습니다. 다음 우선순위 태스크로 진행할게요!

## 🟢 완료 조건
- 터미널 리사이징이 가능하다.

## ✍ 궁금한 점
- 코드 관련 폰트 classname 스타일에 font-size가 지정이 안되어있어서 13px (기존 크기) 로 지정했는데 괜찮을까요?