### PR TITLE
[BE] feat#204 캐리지 리턴 적용하는 함수 구현 및 stdout/stderr에 적용

### DIFF
--- a/packages/backend/src/common/util.ts
+++ b/packages/backend/src/common/util.ts
@@ -1,3 +1,15 @@
 export function preview(message: string): string {
   return message.length > 15 ? message.slice(0, 20) + '...' : message;
 }
+
+export function processCarriageReturns(data: string) {
+  return data
+    .split('\n')
+    .map((line) => {
+      const carriageReturnIndex = line.lastIndexOf('\r');
+      return carriageReturnIndex !== -1
+        ? line.substring(carriageReturnIndex + 1)
+        : line;
+    })
+    .join('\n');
+}

--- a/packages/backend/src/ssh/ssh.service.ts
+++ b/packages/backend/src/ssh/ssh.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { SSHConnectionPoolService } from './ssh.connection-pool.service';
+import { processCarriageReturns } from '../common/util';
 
 @Injectable()
 export class SshService {
@@ -26,7 +27,10 @@ export class SshService {
         stream
           .on('close', () => {
             this.sshPool.returnConnection(sshConnection);
-            resolve({ stdoutData, stderrData });
+            resolve({
+              stdoutData: processCarriageReturns(stdoutData),
+              stderrData: processCarriageReturns(stderrData),
+            });
           })
           .on('data', (data) => {
             stdoutData += data.toString();


### PR DESCRIPTION
close #204 

## ✅ 작업 내용

- \r의 경우 이전 라인을 지우는데, 이를 서버에서 해석하여 응답한다.
  - 해당 함수 구현
  - stdout/stderr에 적용

## 📸 스크린샷(BE도!)

### before
![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/7cd3d79a-0f71-49d8-80bf-fee9af66ab5e)


### after
<img width="1020" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/78bddea4-b10e-4c35-b507-a23ab33dd91d">


## 📌 이슈 사항

- 없습니다!

## 🟢 완료 조건

- 캐리지 리턴이 해석되어 응답된다.
- 모든 테스트 코드도 통과!

## ✍ 궁금한 점

- 없습니다!