### PR TITLE
[BE] feat#153 13번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/common/util.ts
+++ b/packages/backend/src/common/util.ts
@@ -1,3 +1,15 @@
 export function preview(message: string): string {
   return message.length > 15 ? message.slice(0, 20) + '...' : message;
 }
+
+export function processCarriageReturns(data: string) {
+  return data
+    .split('\n')
+    .map((line) => {
+      const carriageReturnIndex = line.lastIndexOf('\r');
+      return carriageReturnIndex !== -1
+        ? line.substring(carriageReturnIndex + 1)
+        : line;
+    })
+    .join('\n');
+}

--- a/packages/backend/src/quiz-wizard/magic.ts
+++ b/packages/backend/src/quiz-wizard/magic.ts
@@ -58,10 +58,11 @@ export class Magic {
 
   async getCommitHashByMessage(
     container: string,
+    branch: string,
     message: string,
   ): Promise<string> {
     const { stdoutData } = await this.sshService.executeSSHCommand(
-      `docker exec -u quizzer -w /home/quizzer/quiz ${container} sh -c "git log --grep='^${message}$' --oneline --reverse | awk '{print \\\$1}'"`,
+      `docker exec -u quizzer -w /home/quizzer/quiz ${container} sh -c "git log --grep='^${message}$' --oneline --reverse ${branch} | awk '{print \\\$1}'"`,
     );
 
     return stdoutData.trim();

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -17,6 +17,7 @@ export class QuizWizardService {
     9: (containerId: string) => this.checkCondition9(containerId),
     10: (containerId: string) => this.checkCondition10(containerId),
     12: (containerId: string) => this.checkCondition12(containerId),
+    13: (containerId: string) => this.checkCondition13(containerId),
   };
 
   async submit(containerId: string, quizId: number) {
@@ -77,6 +78,7 @@ index e69de29..3b18e51 100644
   async checkCondition7(containerId: string): Promise<boolean> {
     const amendCommitHash = await this.magic.getCommitHashByMessage(
       containerId,
+      'feat/somethingB',
       '회원가입 기능 구현',
     );
     if (
@@ -101,6 +103,7 @@ index e69de29..3b18e51 100644
     try {
       const commitHash = await this.magic.getCommitHashByMessage(
         containerId,
+        'feat/somethingB',
         '회원가입 테스트 코드 작성',
       );
       if (
@@ -127,6 +130,7 @@ index e69de29..3b18e51 100644
 
       const commitHashSecond = await this.magic.getCommitHashByMessage(
         containerId,
+        'feat/somethingB',
         '회원가입 기능 구현',
       );
       if (
@@ -186,5 +190,43 @@ index e69de29..3b18e51 100644
     }
 
     return true;
+  }
+
+  async checkCondition13(containerId: string): Promise<boolean> {
+    try {
+      const messages = [
+        '회원탈퇴 기능 구현',
+        '로그인 테스트 코드 작성',
+        '로그인 기능 구현',
+      ];
+      const hashes = [
+        'ad5fe01b96edeab9ebd213a4069ea9d6f313eec3',
+        '64d5e0c4675ca4b51d1e5e66bbcc703bc785308f',
+        '86eff1319c698fdd99b9c2289d4f66f0498ca040',
+        '3c363aeb69b28b176bf565dba6bb8a3a92d9fd5d',
+      ];
+
+      for (const [index, message] of messages.entries()) {
+        const commitHash = await this.magic.getCommitHashByMessage(
+          containerId,
+          'feat/somethingB',
+          message,
+        );
+
+        if (
+          !commitHash ||
+          (await this.magic.getTreeHead(containerId, commitHash)) !==
+            hashes[index] ||
+          (await this.magic.getTreeHead(containerId, `${commitHash}~1`)) !==
+            hashes[index + 1]
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/backend/src/ssh/ssh.service.ts
+++ b/packages/backend/src/ssh/ssh.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { SSHConnectionPoolService } from './ssh.connection-pool.service';
+import { processCarriageReturns } from '../common/util';
 
 @Injectable()
 export class SshService {
@@ -26,7 +27,10 @@ export class SshService {
         stream
           .on('close', () => {
             this.sshPool.returnConnection(sshConnection);
-            resolve({ stdoutData, stderrData });
+            resolve({
+              stdoutData: processCarriageReturns(stdoutData),
+              stderrData: processCarriageReturns(stderrData),
+            });
           })
           .on('data', (data) => {
             stdoutData += data.toString();


### PR DESCRIPTION
close #153 

## ✅ 작업 내용

- 13번 문제 테스트 케이스 작성
- 7번 문제 테스트 케이스 업데이트
  - 잘 풀고 마지막에 브랜치만 바꾸는 경우 추가(이것도 정답)
- 커밋 메시지로 커밋 해시 찾을 때 브랜치 명시하도록 변경(없으면 현재 브랜치 기준이라 잘못 채점 가능)
- 13번 문제 채점 로직 구현

## 📌 이슈 사항

- 없습니다.

## 🟢 완료 조건

- 모든 테스트 케이스 통과
- 13번 문제 채점 가능

## ✍ 궁금한 점

- 없습니다!
