### PR TITLE
[BE] feat#146 17번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -20,6 +20,7 @@ export class QuizWizardService {
     13: (containerId: string) => this.checkCondition13(containerId),
     15: (containerId: string) => this.checkCondition15(containerId),
     16: (containerId: string) => this.checkCondition16(containerId),
+    17: (containerId: string) => this.checkCondition17(containerId),
   };
 
   async submit(containerId: string, quizId: number) {
@@ -255,5 +256,12 @@ upstream	/upstream (push)
 
   async checkCondition16(containerId: string): Promise<boolean> {
     return (await this.magic.getNowBranch(containerId)) === 'feat/somethingA';
+  }
+
+  async checkCondition17(containerId: string): Promise<boolean> {
+    return (
+      (await this.magic.getTreeHead(containerId, 'main')) ===
+      '3bd4e8ab14ecf1c7e1e85262ce241c4275080270'
+    );
   }
 }

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -1164,76 +1164,121 @@ describe('QuizWizardController (e2e)', () => {
 
       expect(response.body).toHaveProperty('solved', false);
     });
+  });
 
-    describe('16번 문제 채점 테스트', () => {
-      const id = 16;
-      afterEach(async () => {
-        await request(app.getHttpServer())
-          .delete(`/api/v1/quizzes/${id}/command`)
-          .set('Cookie', cookie);
-      });
+  describe('16번 문제 채점 테스트', () => {
+    const id = 16;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
 
-      it('베스트 성공 케이스', async () => {
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/command`)
-          .send({
-            mode: 'command',
-            message: 'git switch -c feat/somethingA',
-          });
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git switch -c feat/somethingA',
+        });
 
-        cookie = response.headers['set-cookie'][0].split(';')[0];
+      cookie = response.headers['set-cookie'][0].split(';')[0];
 
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/submit`)
-          .set('Cookie', cookie)
-          .expect(200);
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
 
-        expect(response.body).toHaveProperty('solved', true);
-      });
+      expect(response.body).toHaveProperty('solved', true);
+    });
 
-      it('괜히 다시 main으로 돌아옴', async () => {
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/command`)
-          .send({
-            mode: 'command',
-            message: 'git switch -c feat/somethingA',
-          });
+    it('괜히 다시 main으로 돌아옴', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git switch -c feat/somethingA',
+        });
 
-        cookie = response.headers['set-cookie'][0].split(';')[0];
+      cookie = response.headers['set-cookie'][0].split(';')[0];
 
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/command`)
-          .set('Cookie', cookie)
-          .send({
-            mode: 'command',
-            message: 'git checkout main',
-          });
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git checkout main',
+        });
 
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/submit`)
-          .set('Cookie', cookie)
-          .expect(200);
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
 
-        expect(response.body).toHaveProperty('solved', false);
-      });
+      expect(response.body).toHaveProperty('solved', false);
+    });
 
-      it('아무것도 안 함', async () => {
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/command`)
-          .send({
-            mode: 'command',
-            message: 'git status',
-          });
+    it('아무것도 안 함', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
 
-        cookie = response.headers['set-cookie'][0].split(';')[0];
+      cookie = response.headers['set-cookie'][0].split(';')[0];
 
-        response = await request(app.getHttpServer())
-          .post(`/api/v1/quizzes/${id}/submit`)
-          .set('Cookie', cookie)
-          .expect(200);
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
 
-        expect(response.body).toHaveProperty('solved', false);
-      });
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
+  describe('17번 문제 채점 테스트', () => {
+    const id = 17;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git pull origin main',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('아무것도 안 함', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
     });
   });
 


### PR DESCRIPTION
close #146 

## ✅ 작업 내용

- 17번 문제 origin, upstream 포함하여 container 서버에 구현
- 17번 문제 채점 테스트 케이스 작성
- 17번 문제 채점 로직 구현

## 📌 이슈 사항

- 없습니다.

## 🟢 완료 조건

- 17번 문제 채점 가능
- 모든 테스트케이스 통과

## ✍ 궁금한 점

- 없습니다!