### PR TITLE
[FE] config#216 테스트 환경에서 vanilla extract 변환 설정 추가

### DIFF
--- a/packages/frontend/jest.config.mjs
+++ b/packages/frontend/jest.config.mjs
@@ -1,18 +1,24 @@
-import nextJest from 'next/jest.js'
+import nextJest from "next/jest.js";
 
 const createJestConfig = nextJest({
-    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-    dir: './',
-})
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: "./",
+});
 
-// Add any custom config to be passed to Jest
-/** @type {import('jest').Config} */
-const config = {
-    // Add more setup options before each test is run
-    // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+const customJestConfig = {
+  testEnvironment: "jsdom",
+};
 
-    testEnvironment: 'jsdom',
+export default async function config() {
+  const nextJestConfig = await createJestConfig(customJestConfig)();
+
+  delete nextJestConfig.moduleNameMapper["^.+\\.(css|sass|scss)$"]; // Next.js 기본 설정 삭제
+
+  return {
+    ...nextJestConfig,
+    transform: {
+      "\\.css\\.ts$": "@vanilla-extract/jest-transform", // Jest transform 설정
+      ...nextJestConfig.transform,
+    },
+  };
 }
-
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-export default createJestConfig(config)

--- a/packages/frontend/jest.config.mjs
+++ b/packages/frontend/jest.config.mjs
@@ -10,12 +10,18 @@ const customJestConfig = {
 };
 
 export default async function config() {
+  const styleFileRegex = "^.+\\.(css|sass|scss)$";
   const nextJestConfig = await createJestConfig(customJestConfig)();
 
-  delete nextJestConfig.moduleNameMapper["^.+\\.(css|sass|scss)$"]; // Next.js 기본 설정 삭제
+  const defaultMapper = nextJestConfig.moduleNameMapper[styleFileRegex]; // Next.js 기본 설정 삭제
+  delete nextJestConfig.moduleNameMapper[styleFileRegex];
 
   return {
     ...nextJestConfig,
+    moduleNameMapper: {
+      "design-system/styles/.+\\.css$": defaultMapper,
+      ...nextJestConfig.moduleNameMapper,
+    },
     transform: {
       "\\.css\\.ts$": "@vanilla-extract/jest-transform", // Jest transform 설정
       ...nextJestConfig.transform,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -46,6 +46,7 @@
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
+    "@vanilla-extract/jest-transform": "^1.1.1",
     "@vanilla-extract/next-plugin": "^2.3.2",
     "@vanilla-extract/webpack-plugin": "^2.3.1",
     "css-loader": "^6.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5769,7 +5769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/integration@npm:^6.0.0":
+"@vanilla-extract/integration@npm:^6.0.0, @vanilla-extract/integration@npm:^6.2.0":
   version: 6.2.4
   resolution: "@vanilla-extract/integration@npm:6.2.4"
   dependencies:
@@ -5787,6 +5787,16 @@ __metadata:
     vite: "npm:^4.1.4"
     vite-node: "npm:^0.28.5"
   checksum: 19cf40f8b721ee731fdcaff5cededde821b554ea44b4f57167d77769f7b381d7a71a3beba63c1daed02695b95b391ebedca47887138d8c760f4151570b1ef634
+  languageName: node
+  linkType: hard
+
+"@vanilla-extract/jest-transform@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@vanilla-extract/jest-transform@npm:1.1.1"
+  dependencies:
+    "@vanilla-extract/integration": "npm:^6.2.0"
+    esbuild: "npm:0.17.6"
+  checksum: 07d3140d1454657532d6a6c686bf849fb6a4c505fd12834991640582c5071626f31cf10dd2e1202406788572f040cde6cd5918392da90359a909500cdfe3da0f
   languageName: node
   linkType: hard
 
@@ -10334,6 +10344,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.11.0"
     "@typescript-eslint/parser": "npm:^6.11.0"
     "@vanilla-extract/css": "npm:^1.14.0"
+    "@vanilla-extract/jest-transform": "npm:^1.1.1"
     "@vanilla-extract/next-plugin": "npm:^2.3.2"
     "@vanilla-extract/webpack-plugin": "npm:^2.3.1"
     axios: "npm:^1.6.2"


### PR DESCRIPTION
close #216 

## ✅ 작업 내용
- @vanilla-extract/jest-transform  추가 및 설정

cf. Next.js 기본 동작 때문에 설정하는데 오래 걸렸습니다..! 자세한 내용은 [노션 개발 위키](https://www.notion.so/Next-js-Jest-Vanilla-extract-7f24b3e7426a4e869bd59808849e013f)에 작성했습니다!

## 📸 스크린샷
**객체 형태의 vanilla-extract import 문이 있어도 테스트가 성공하며 변환된 클래스 이름이 할당됨**

|테스트용 코드|테스트 결과|
|-|-|
|<img width="761" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/f415f232-aa9a-449f-af0c-9aca078e6805">|<img width="1100" alt="image-20231204004315622" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/159d89d6-44a2-404c-ace9-d3df5048e1d4">|

**.css 파일을 import 해도 테스트가 성공함**
|테스트용 코드|테스트 결과|
|-|-|
|<img width="685" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/83f79f70-0738-4938-b534-fd09d22da43f">|<img width="595" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/bbbc36f8-a7d8-493c-a847-b193dad746cb">|



## 📌 이슈 사항
- 없습니다

## 🟢 완료 조건
- 테스트 환경에서 HTML 클래스 이름에 vanilla-extract 코드가 변환되어 설정된다.
- 객체 형태의 vanilla-extract import 문이 있어도 테스트가 성공한다.
- vanilla-extract가 아닌 .css 파일을 import 해도 테스트가 성공한다.

## ✍ 궁금한 점
- 없습니다!
