### PR TITLE
[BE] feat#224 세션 통신 개선

### DIFF
--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -11,6 +11,7 @@ import {
   Delete,
   UseGuards,
   HttpCode,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -39,9 +40,11 @@ import { QuizWizardService } from '../quiz-wizard/quiz-wizard.service';
 import { Fail, SubmitDto, Success } from './dto/submit.dto';
 import { preview } from '../common/util';
 import { QuizGuard } from './quiz.guard';
+import { SessionUpdateInterceptor } from '../session/session-save.intercepter';
 
 @ApiTags('quizzes')
 @Controller('api/v1/quizzes')
+@UseInterceptors(SessionUpdateInterceptor)
 export class QuizzesController {
   constructor(
     private readonly quizService: QuizzesService,

--- a/packages/backend/src/session/session-save.intercepter.ts
+++ b/packages/backend/src/session/session-save.intercepter.ts
@@ -1,0 +1,35 @@
+import { tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { SessionService } from './session.service';
+import { Response } from 'express';
+
+@Injectable()
+export class SessionUpdateInterceptor implements NestInterceptor {
+  constructor(private sessionService: SessionService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const response: Response = context.switchToHttp().getResponse();
+    let sessionId = request.cookies.sessionId; // 세션 ID 추출
+
+    return next.handle().pipe(
+      tap(() => {
+        sessionId =
+          sessionId || this.extractSessionId(response.getHeader('Set-Cookie')); // 세션 ID가 없으면 쿠키에서 추출
+        // 세션 업데이트 로직
+        this.sessionService.saveSession(sessionId);
+      }),
+    );
+  }
+
+  private extractSessionId(cookieStr) {
+    const sessionIdMatch = /sessionId=([^;]+)/.exec(cookieStr);
+    return sessionIdMatch ? sessionIdMatch[1] : null;
+  }
+}

--- a/packages/backend/src/session/session.controller.ts
+++ b/packages/backend/src/session/session.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Delete, Res } from '@nestjs/common';
+import { Controller, Delete, Res, UseInterceptors } from '@nestjs/common';
 import { SessionService } from './session.service';
 import { SessionId } from './session.decorator';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
+import { SessionUpdateInterceptor } from './session-save.intercepter';
 
 @ApiTags('session')
 @Controller('api/v1/session')
+@UseInterceptors(SessionUpdateInterceptor)
 export class SessionController {
   constructor(private readonly sessionService: SessionService) {}
 


### PR DESCRIPTION
close #224 

## ✅ 작업 내용
- SessionUpdateInterceptor 도입
- 컨트롤러에 Intercepter 도입
- 세션 Map 도입
- 1요청 2통신으로 get, save로 개선

## 📌 이슈 사항
- 기존 코드의 변경을 최소화하면서 적용했습니다!

## 🟢 완료 조건
- 한번 요청에 세션 업데이트 통신은 한번만 하도록 한다

## ✍ 궁금한 점
- 이제 모든 요청에 세션과 관련된 일은 한번만 통신합니다!
- 동일 세션으로부터 요청을 막는 Guard도 도입해 볼까요..?