### PR TITLE
[BE] feat#144 18번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -73,8 +73,10 @@ export class ContainersService {
 --name ${containerId} mergemasters/alpine-git:0.2 /bin/sh`;
     const copyFilesCommand = `docker cp ~/quizzes/${quizId}/. ${containerId}:/home/${user}/quiz/`;
     const copyOriginCommand = `[ -d ~/origins/${quizId} ] && docker cp ~/origins/${quizId}/. ${containerId}:/origin/`;
-    const copyUpstreamCommand = `[ -d ~/upstreams/${quizId} ]docker cp ~/upstreams/${quizId}/. ${containerId}:/upstream/`;
+    const copyUpstreamCommand = `[ -d ~/upstreams/${quizId} ] && docker cp ~/upstreams/${quizId}/. ${containerId}:/upstream/`;
     const chownCommand = `docker exec -u root ${containerId} chown -R ${user}:${user} /home/${user}`;
+    const chownOriginCommand = `[ -d ~/origins/${quizId} ] && docker exec -u root ${containerId} chown -R ${user}:${user} /origin`;
+    const chownUpstreamCommand = `[ -d ~/upstreams/${quizId} ] && docker exec -u root ${containerId} chown -R ${user}:${user} /remote`;
     const coreEditorCommand = `docker exec -w /home/quizzer/quiz/ -u ${user} ${containerId} git config --global core.editor /editor/output.sh`;
     await this.sshService.executeSSHCommand(
       createContainerCommand,
@@ -82,6 +84,8 @@ export class ContainersService {
       copyOriginCommand,
       copyUpstreamCommand,
       chownCommand,
+      chownOriginCommand,
+      chownUpstreamCommand,
       coreEditorCommand,
     );
 

--- a/packages/backend/src/quiz-wizard/magic.ts
+++ b/packages/backend/src/quiz-wizard/magic.ts
@@ -107,4 +107,27 @@ export class Magic {
 
     return stdoutData;
   }
+
+  async isBranchExistRemote(
+    container: string,
+    remote: string,
+    branch: string,
+  ): Promise<boolean> {
+    const command = `docker exec  -u quizzer -w /${remote} ${container} git branch --list '${branch}'`;
+    const { stdoutData } = await this.sshService.executeSSHCommand(command);
+
+    return stdoutData.trim() !== '';
+  }
+
+  async getTreeHeadRemote(
+    container: string,
+    remote: string,
+    branch: string,
+  ): Promise<string> {
+    const { stdoutData } = await this.sshService.executeSSHCommand(
+      `docker exec -u quizzer -w /${remote} ${container} sh -c "git cat-file -p \\\$(git rev-parse ${branch}) | grep tree | awk '{print \\\$2}'"`,
+    );
+
+    return stdoutData.trim();
+  }
 }

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -8,7 +8,7 @@ export class QuizWizardService {
   async submit(containerId: string, quizId: number) {
     const checker = this[`checkCondition${quizId}`];
     if (checker) {
-      return await checker(containerId);
+      return await checker.call(this, containerId);
     }
     return false;
   }
@@ -273,6 +273,30 @@ upstream	/upstream (push)
       (await this.magic.getTreeHead(containerId, 'main')) ===
       '3bd4e8ab14ecf1c7e1e85262ce241c4275080270'
     );
+  }
+
+  async checkCondition18(containerId: string): Promise<boolean> {
+    if (
+      !(await this.magic.isBranchExistRemote(
+        containerId,
+        'origin',
+        'feat/merge-master',
+      ))
+    ) {
+      return false;
+    }
+
+    if (
+      (await this.magic.getTreeHeadRemote(
+        containerId,
+        'origin',
+        'feat/merge-master',
+      )) !== 'd173eb2b7c6888bf77fce84b191a433f36c47a91'
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   async checkCondition19(containerId: string): Promise<boolean> {

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -1411,6 +1411,67 @@ describe('QuizWizardController (e2e)', () => {
     });
   });
 
+  describe('18번 문제 채점 테스트', () => {
+    const id = 18;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git add .',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git commit -m "feat: mergemaster 구현"',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'command',
+          message: 'git push -u origin feat/merge-master',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('아무것도 안 하고 채점', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
   describe('19번 문제 채점 테스트', () => {
     const id = 19;
     afterEach(async () => {


### PR DESCRIPTION
close #144 

## ✅ 작업 내용

- 18번 문제 작성
- 18번 문제 컨테이너 서버에 구현
- 18번 문제 채점 테스트 케이스 작성
- 18번 문제 채점 로직 구현

## 📌 이슈 사항

- 없습니다!

## 🟢 완료 조건

- 18번 문제 채점 가능
- 모든 테스트 케이스 통과

## ✍ 궁금한 점

 - 없습니다!