### PR TITLE
[FE] style#220 리사이징 바 표시

### DIFF
--- a/packages/frontend/src/design-system/tokens/layout.css.ts
+++ b/packages/frontend/src/design-system/tokens/layout.css.ts
@@ -3,8 +3,8 @@ import { style } from "@vanilla-extract/css";
 import {
   flex,
   flexColumn,
-  middleLayer,
   scrollBarHidden,
+  topLayer,
   widthFull,
   widthMax,
 } from "./utils.css";
@@ -13,7 +13,7 @@ const headerHeight = "56px";
 const footerHeight = "250px";
 
 export const header = style([
-  middleLayer,
+  topLayer,
   widthFull,
   {
     height: headerHeight,

--- a/packages/frontend/src/pages/quizzes/quiz.css.ts
+++ b/packages/frontend/src/pages/quizzes/quiz.css.ts
@@ -13,10 +13,24 @@ export const bar = style([
   middleLayer,
   border.all,
   {
+    position: "relative",
     minHeight: 20,
     borderBottom: "none",
     backgroundColor: color.$scale.grey100,
     cursor: "row-resize",
+
+    "::before": {
+      content: "",
+      position: "absolute",
+      left: "50%",
+      transform: "translateX(-50%)",
+      display: "block",
+      width: 60,
+      height: 3,
+      borderRadius: 8,
+      backgroundColor: color.$scale.grey400,
+      top: -5,
+    },
   },
 ]);
 


### PR DESCRIPTION
close #220

## ✅ 작업 내용
- 리사이즈가 가능함을 표시한다.

## 📸 스크린샷
![resize 1column](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/a6865551-186c-498c-aeb1-e51506a16c15)

## 📌 이슈 사항
- 리사이즈를 최상단까지 하면 헤더를 침범합니다..! 헤더랑 리사이즈 표시에 `z-index`를 설정하면 아래처럼 가려지는데 어떻게 할까요? 저는 가려지는 게 좋은 것 같아요!
![resize header](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/ab1ae73f-c12b-42f6-954f-4171fd8a9302)
- #219 작업하려면 리사이즈 바 스타일을 터미널이랑 편집기 각각 줘야할 것 같아요..! 아니면 편집기 모드일 때 폴더 경로랑 명령어를 리사이즈 바에 넣어야 돼요🥹

## 🟢 완료 조건
- 사용자가 리사이즈가 가능함을 알 수 있다.

## ✍ 궁금한 점
- 없습니다!
