### PR TITLE
[BE] feat#160 정답 시 로그 암호화 구현 및 채점 API 완성

### DIFF
--- a/packages/backend/src/quizzes/dto/submit.dto.ts
+++ b/packages/backend/src/quizzes/dto/submit.dto.ts
@@ -6,12 +6,15 @@ export class Success {
   @IsBoolean()
   solved = true;
 
-  @ApiProperty({ example: 'gitchallenge.com/api/v1/quizzes/shared?answer=””' })
+  @ApiProperty({
+    description: '인코딩된 문제 풀이 과정과 문제 번호',
+    example: '6251ee88d6e378b5d6b862447d151dab:aa88c19acf3da6(좀 더 길어요)',
+  })
   @IsString()
-  link: string;
+  slug: string;
 
-  constructor(link: string) {
-    this.link = link;
+  constructor(slug: string) {
+    this.slug = slug;
   }
 }
 

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -38,7 +38,7 @@ import { SessionId } from '../session/session.decorator';
 import { CommandGuard } from '../common/command.guard';
 import { QuizWizardService } from '../quiz-wizard/quiz-wizard.service';
 import { Fail, SubmitDto, Success } from './dto/submit.dto';
-import { preview } from '../common/util';
+import { encryptObject, preview } from '../common/util';
 import { QuizGuard } from './quiz.guard';
 import { SessionUpdateInterceptor } from '../session/session-save.intercepter';
 
@@ -314,9 +314,19 @@ export class QuizzesController {
         return new Fail();
       }
 
-      //create link
-      return new Success('notImplemented');
+      const commands = (
+        await this.sessionService.getLogObject(sessionId, id)
+      ).logs
+        .filter((log) => log.mode === 'command')
+        .map((log) => log.message);
+      const encodedCommands = encryptObject({
+        id,
+        commands,
+      });
+
+      return new Success(encodedCommands);
     } catch (e) {
+      this.logger.log('error', e);
       throw new HttpException(
         {
           message: 'Internal Server Error',


### PR DESCRIPTION
close #160 

## ✅ 작업 내용

- 암호화, 복호화 util함수 구현
- 복호화 시 문자열 배열인지 확인하는 가드 작성
- 채점 정답 시 로그를 읽어와 command만 문자열 배열로 추출한 뒤 id와 commands를 저장하는 객체를 암호화하여 리턴

## 📌 이슈 사항

- 문자열만 리턴하는 것으로 명세가 바뀌었습니다. (기존 전체 링크)

## 🟢 완료 조건

- 객체 암호화 및 복호화 가능
- 채점 완료 시 암호화 문자열 생성
- 바뀐 명세 수정 및 Swagger 반영

## ✍ 궁금한 점

- 없습니다!