### PR TITLE
[BE] feat#161 shared API 구현

### DIFF
--- a/packages/backend/src/quizzes/dto/shared.dto.ts
+++ b/packages/backend/src/quizzes/dto/shared.dto.ts
@@ -7,7 +7,7 @@ export class Decrypted {
   readonly commands: string[];
 }
 
-export function isEncryptedDto(obj: unknown): obj is Decrypted {
+export function isDecrypted(obj: unknown): obj is Decrypted {
   const isObject = (val: unknown): val is { [key: string]: unknown } =>
     typeof val === 'object' && val !== null;
 

--- a/packages/backend/src/quizzes/dto/shared.dto.ts
+++ b/packages/backend/src/quizzes/dto/shared.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray } from 'class-validator';
+import { QuizDto } from './quiz.dto';
+
+export class Decrypted {
+  readonly id: string;
+  readonly commands: string[];
+}
+
+export function isEncryptedDto(obj: unknown): obj is Decrypted {
+  const isObject = (val: unknown): val is { [key: string]: unknown } =>
+    typeof val === 'object' && val !== null;
+
+  if (!isObject(obj)) {
+    return false;
+  }
+
+  return (
+    typeof obj.id === 'string' &&
+    Array.isArray(obj.commands) &&
+    obj.commands.every((cmd) => typeof cmd === 'string')
+  );
+}
+
+export class SharedDto {
+  @ApiProperty({
+    description: '공유받은 답안',
+    example: '["git status", "git add docs/plan.md"]',
+  })
+  @IsArray()
+  readonly answer: string[];
+
+  @ApiProperty({
+    description: '공유받은 답안의 문제 상황',
+    example: {
+      id: 3,
+      title: 'git add & git status',
+      description:
+        '현재 변경된 파일 중에서 `achitecture.md` 파일을 제외하고 staging 해주세요.',
+      keywords: ['add', 'status'],
+      category: 'Git Start',
+    },
+  })
+  readonly quiz: QuizDto;
+
+  constructor(answer: string[], quiz: QuizDto) {
+    this.answer = answer;
+    this.quiz = quiz;
+  }
+}
+
+export class BadRequestResponseDto {
+  @ApiProperty({
+    description:
+      '제공된 암호화된 문자열이 유효하지 않거나, 복호화에 실패했습니다.',
+    example: '공유된 문제가 올바르지 않습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: `Bad Request`,
+    example: 'Bad Request',
+  })
+  error?: string;
+
+  @ApiProperty({
+    description: `statusCode`,
+    example: 400,
+  })
+  statusCode: number;
+
+  constructor(message: string, error?: string) {
+    this.message = message;
+    this.statusCode = 400;
+    this.error = error;
+  }
+}

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -47,7 +47,7 @@ import { SessionUpdateInterceptor } from '../session/session-save.intercepter';
 import {
   BadRequestResponseDto,
   SharedDto,
-  isEncryptedDto,
+  isDecrypted,
 } from './dto/shared.dto';
 
 @ApiTags('quizzes')
@@ -349,7 +349,7 @@ export class QuizzesController {
     try {
       const decrypted = decryptObject(answer);
 
-      if (!isEncryptedDto(decrypted)) {
+      if (!isDecrypted(decrypted)) {
         throw new HttpException(
           '공유된 문제가 올바르지 않습니다.',
           HttpStatus.BAD_REQUEST,

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -347,9 +347,7 @@ export class QuizzesController {
   })
   async shared(@Query('answer') answer: string): Promise<SharedDto> {
     try {
-      console.log(answer);
       const decrypted = decryptObject(answer);
-      console.log(decrypted);
 
       if (!isEncryptedDto(decrypted)) {
         throw new HttpException(

--- a/packages/backend/test/api.e2e-spec.ts
+++ b/packages/backend/test/api.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import { AppModule } from '../src/app.module';
+
+describe('QuizWizardController (e2e)', () => {
+  let app: INestApplication;
+  let response;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(cookieParser());
+
+    await app.init();
+  });
+
+  describe('GET shared?answer=""', () => {
+    it('200', async () => {
+      response = await request(app.getHttpServer())
+        .get(
+          `/api/v1/quizzes/shared?answer=644c3dc58a933571fd27ef95579b713c:618074da8a6d55a6b2b29e955942c887988ea264ab23ce6e99ef9fb09dbfc11ae6ca2c1c3e77c73370f6cc83d47600aaf6d702db3ad208febe6d81be7e9e4d30`,
+        )
+        .expect(200);
+
+      expect(response.body.answer).toEqual(['git add .', 'git commit']);
+      expect(response.body.quiz.id).toEqual(4);
+    });
+
+    it('400 잘못된 문자열', async () => {
+      response = await request(app.getHttpServer())
+        .get(`/api/v1/quizzes/shared?answer=""`)
+        .expect(400);
+    });
+
+    it('400 복호화 했는데 이상함', async () => {
+      response = await request(app.getHttpServer())
+        .get(`/api/v1/quizzes/shared?answer=""`)
+        .expect(400);
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
close #161 

## ✅ 작업 내용

- shared DTO 선언
- shared API에 대한 e2e 테스트 코드 작성
- shared API 구현
- swagger 선언

## 📌 이슈 사항

- shared.dto.ts에 있는 Decrypted라는 클래스가 있는데, 저희 내부적으로 복호화된 객체를 다루는 클래스입니다. id가 스트링인데, 이는 json으로 압축할 때 stringify 써서 string으로 하는 편이 꽤 유리합니다.
- 400 에러가 추가됐는데, 복호화 실패나 복호화된 값이 이상할 때입니다.

## 🟢 완료 조건

- shared api 사용 가능
- 테스트 코드 통과

## ✍ 궁금한 점

- 없습니다!
