### PR TITLE
[BE] feat#229 컨테이너 풀 및 컨테이너 타임아웃 삭제 구현

### DIFF
--- a/packages/backend/src/command/command.service.ts
+++ b/packages/backend/src/command/command.service.ts
@@ -31,4 +31,17 @@ export class CommandService {
       this.logger.log('info', error);
     }
   }
+
+  async executeCron(
+    ...commands: string[]
+  ): Promise<{ stdoutData: string; stderrData: string }> {
+    try {
+      const command = commands.join('; ');
+      this.logger.log('info', `command: ${preview(command, 40)}`);
+      const response = await this.instance.post('/cron', { command });
+      return response.data;
+    } catch (error) {
+      this.logger.log('info', error);
+    }
+  }
 }

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -4,6 +4,10 @@ import request from 'supertest';
 import cookieParser from 'cookie-parser';
 import { AppModule } from '../src/app.module';
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('QuizWizardController (e2e)', () => {
   let app: INestApplication;
   let response;
@@ -19,6 +23,8 @@ describe('QuizWizardController (e2e)', () => {
     app.use(cookieParser());
 
     await app.init();
+
+    await sleep(5000);
   });
 
   describe('1번 문제 채점 테스트', () => {


### PR DESCRIPTION
close #229 

## ✅ 작업 내용

- 컨테이너 풀 구현
  - 서버 생성 시 문제 별 컨테이너 기본값 1개를 만들어 둠 (이벤트 앞두고 늘려줄 계획)
  - 컨테이너 가 발급되면 바로 재생성
- 컨테이너 restore 시 docker exec sh -c "" 안에 명령을 모으도록 변경
- getContainer 시 자동으로 30분 뒤에 컨테이너가 삭제도되록 구현
- cron job을 위한 command service 로직 추가(컨테이너 서버에도 구현했어요)

## 📌 이슈 사항

- 과연 14번 빨리 할 수 있나요?!
- 이제 컨테이너가 너무 많아져서 컨테이너 서버 로컬에 clearContainer.sh 만들었어요. bash clearContainer.sh 입력하면 다 정리돼요.

## 🟢 완료 조건

- 컨테이너 최초 생성 시 400ms 이상, restore 시 500ms 이상 정도로 속도 향상
- 모든 테스트 케이스 통과
- 컨테이너 자동 삭제 가능

## ✍ 궁금한 점

- 없습니다!
