### PR TITLE
[BE] feat#151 14번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/command/command.service.ts
+++ b/packages/backend/src/command/command.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { Logger } from 'winston';
-import { preview } from '../common/util';
+import { preview, processCarriageReturns } from '../common/util';
 
 @Injectable()
 export class CommandService {
@@ -26,7 +26,10 @@ export class CommandService {
       const command = commands.join('; ');
       this.logger.log('info', `command: ${preview(command, 40)}`);
       const response = await this.instance.post('/', { command });
-      return response.data;
+      return {
+        stdoutData: processCarriageReturns(response.data.stdoutData),
+        stderrData: processCarriageReturns(response.data.stderrData),
+      };
     } catch (error) {
       this.logger.log('info', error);
     }

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -222,16 +222,21 @@ export class ContainersService {
 
     let recentMessage = '';
 
-    const commands: string[] = logs.map((log) => {
+    const commands = logs.reduce((acc, log, index, array) => {
       if (log.mode === 'command') {
         recentMessage = log.message;
-        return log.message;
+        if (array[index + 1] && array[index + 1].mode === 'editor') {
+          return acc;
+        }
+        acc.push(log.message);
       } else if (log.mode === 'editor') {
-        return this.buildEditorCommand(log.message, recentMessage);
+        acc.push(this.buildEditorCommand(log.message, recentMessage));
       } else {
         throw new Error('Invalid log mode');
       }
-    });
+
+      return acc;
+    }, []);
 
     await this.commandService.executeCommand(
       this.buildDockerCommand(containerId, ...commands),

--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -243,6 +243,16 @@ index e69de29..bf5c54f 100644
     }
   }
 
+  async checkCondition14(containerId: string): Promise<boolean> {
+    if (
+      (await this.magic.getTreeHead(containerId, 'main')) !==
+      '2f3177d100b90c5a605e97c2fc546502cee2d4a6'
+    )
+      return false;
+
+    return true;
+  }
+
   async checkCondition15(containerId: string): Promise<boolean> {
     if (
       (await this.magic.getTreeHead(containerId, 'main')) !==

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -152,6 +152,18 @@ export class QuizzesController {
           containerId,
           execCommandDto.message,
         ));
+
+        if (result === 'editor') {
+          containerId = await this.containerService.getContainer(id);
+          await this.sessionService.setContainerBySessionId(
+            sessionId,
+            id,
+            containerId,
+          );
+          this.containerService.restoreContainer(
+            await this.sessionService.getLogObject(sessionId, id),
+          );
+        }
       } else if (execCommandDto.mode === MODE.EDITOR) {
         // editor mode
         const { mode: recentMode, message: recentMessage } =

--- a/packages/backend/test/app.e2e-spec.ts
+++ b/packages/backend/test/app.e2e-spec.ts
@@ -1222,6 +1222,95 @@ describe('QuizWizardController (e2e)', () => {
     });
   });
 
+  describe('14번 문제 채점 테스트', () => {
+    const id = 14;
+    afterEach(async () => {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie);
+    });
+
+    it('베스트 성공 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git revert c5d41a925a1ad13da46fb91e62ca7a8e84769b29',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('edit 사용 케이스', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git revert --edit c5d41a925a1ad13da46fb91e62ca7a8e84769b29',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .set('Cookie', cookie)
+        .send({
+          mode: 'editor',
+          message: 'revert commit',
+        });
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', true);
+    });
+
+    it('reset 사용', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git reset c5d41a925a1ad13da46fb91e62ca7a8e84769b29',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+
+    it('아무것도 안 함', async () => {
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/command`)
+        .send({
+          mode: 'command',
+          message: 'git status',
+        });
+
+      cookie = response.headers['set-cookie'][0].split(';')[0];
+
+      response = await request(app.getHttpServer())
+        .post(`/api/v1/quizzes/${id}/submit`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('solved', false);
+    });
+  });
+
   describe('15번 문제 채점 테스트', () => {
     const id = 15;
     afterEach(async () => {


### PR DESCRIPTION
close #151 

## ✅ 작업 내용

- 14번 문제 테스트 케이스 작성
- 14번 문제 채점 로직 작성
- processCarriageReturn 이용하도록 command service 변경
- editor 시 컨테이너를 다시 생성하는 로직 작성
- restore 시에도 reduce 이용하여 사용자와 동일하게 명령 수행

## 📌 이슈 사항

- 없습니다!

## 🟢 완료 조건

- 14번 문제 채점 가능
- 모든 테스트 케이스 통과
- 컨테이너 강제 삭제하더라도 복구된 뒤 같은 상태(채점으로 확인)

## ✍ 궁금한 점

- 없습니다!