### PR TITLE
[FE] feat#221 공유 답안 페이지

### DIFF
--- a/packages/frontend/src/apis/quiz.ts
+++ b/packages/frontend/src/apis/quiz.ts
@@ -1,5 +1,11 @@
 import { API_PATH } from "../constants/path";
-import { Categories, Command, Quiz, QuizSolve } from "../types/quiz";
+import {
+  Categories,
+  Command,
+  Quiz,
+  QuizSolve,
+  SharedQuiz,
+} from "../types/quiz";
 
 import { instance } from "./base";
 
@@ -29,10 +35,21 @@ export const quizAPI = {
     const { data } = await instance.delete(`${API_PATH.QUIZZES}/${id}/command`);
     return data;
   },
+  getSharedAnswer: async (slug: string) => {
+    const { data } = await instance.get<GetSharedAnswerResponse>(
+      `${API_PATH.QUIZZES}/shared?answer=${slug}`,
+    );
+    return data;
+  },
 };
 
 type PostCommandRequest = {
   id: number;
   mode: "command" | "editor";
   message: string;
+};
+
+export type GetSharedAnswerResponse = {
+  answer: string[];
+  quiz: SharedQuiz;
 };

--- a/packages/frontend/src/components/quiz/AnswerCodeBlock/AnswerCodeBlock.css.ts
+++ b/packages/frontend/src/components/quiz/AnswerCodeBlock/AnswerCodeBlock.css.ts
@@ -1,0 +1,21 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+
+import color from "../../../design-system/tokens/color";
+import typography from "../../../design-system/tokens/typography";
+
+export const answerContainer = style([
+  typography.$semantic.body2Regular,
+  {
+    backgroundColor: color.$semantic.bgAlt,
+    borderRadius: 8,
+    width: "100%",
+    padding: "23px 25px",
+    marginBottom: 19,
+    whiteSpace: "break-spaces",
+    color: color.$scale.grey700,
+  },
+]);
+
+globalStyle(`${answerContainer} code`, {
+  color: color.$scale.coral500,
+});

--- a/packages/frontend/src/components/quiz/AnswerCodeBlock/AnswerCodeBlock.tsx
+++ b/packages/frontend/src/components/quiz/AnswerCodeBlock/AnswerCodeBlock.tsx
@@ -1,0 +1,18 @@
+import { toCodeTag } from "../../../utils/mapper";
+
+import { answerContainer } from "./AnswerCodeBlock.css";
+
+interface AnswerCodeBlockProps {
+  answer: string[];
+}
+
+export function AnswerCodeBlock({ answer }: AnswerCodeBlockProps) {
+  return (
+    <p
+      className={answerContainer}
+      dangerouslySetInnerHTML={{
+        __html: toCodeTag(answer.join("\n")),
+      }}
+    />
+  );
+}

--- a/packages/frontend/src/components/quiz/AnswerCodeBlock/index.ts
+++ b/packages/frontend/src/components/quiz/AnswerCodeBlock/index.ts
@@ -1,0 +1,1 @@
+export { AnswerCodeBlock } from "./AnswerCodeBlock";

--- a/packages/frontend/src/components/quiz/QuizAnswerModal/QuizAnswerModal.css.ts
+++ b/packages/frontend/src/components/quiz/QuizAnswerModal/QuizAnswerModal.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 
 import color from "../../../design-system/tokens/color";
 import typography from "../../../design-system/tokens/typography";
@@ -7,20 +7,3 @@ export const h3 = style([
   typography.$semantic.h3,
   { color: color.$scale.grey700, marginBottom: 20 },
 ]);
-
-export const answerContainer = style([
-  typography.$semantic.body2Regular,
-  {
-    backgroundColor: color.$semantic.bgAlt,
-    borderRadius: 8,
-    width: "100%",
-    padding: "23px 25px",
-    marginBottom: 19,
-    whiteSpace: "break-spaces",
-    color: color.$scale.grey700,
-  },
-]);
-
-globalStyle(`${answerContainer} code`, {
-  color: color.$scale.coral500,
-});

--- a/packages/frontend/src/components/quiz/QuizAnswerModal/QuizAnswerModal.tsx
+++ b/packages/frontend/src/components/quiz/QuizAnswerModal/QuizAnswerModal.tsx
@@ -1,5 +1,5 @@
 import { Info, Modal } from "../../../design-system/components/common";
-import { toCodeTag } from "../../../utils/mapper";
+import { AnswerCodeBlock } from "../AnswerCodeBlock";
 
 import * as styles from "./QuizAnswerModal.css";
 
@@ -15,12 +15,7 @@ export default function QuizAnswerModal({
   return (
     <Modal onClose={closeModal}>
       <h3 className={styles.h3}>모범 답안</h3>
-      <p
-        className={styles.answerContainer}
-        dangerouslySetInnerHTML={{
-          __html: toCodeTag(answer.join("\n")),
-        }}
-      />
+      <AnswerCodeBlock answer={answer} />
       <Info>
         본 답안은 모범 답안으로 제공되었으며, 상황에 따라 다양한 해결책이 있을
         수 있습니다.

--- a/packages/frontend/src/components/quiz/index.ts
+++ b/packages/frontend/src/components/quiz/index.ts
@@ -3,3 +3,4 @@ export { default as QuizLocation } from "./QuizLocation";
 export { default as CommandAccordion } from "./CommandAccordion";
 export { SolvedModal, useSolvedModal } from "./SolvedModal";
 export { default as QuizAnswerModal } from "./QuizAnswerModal";
+export { AnswerCodeBlock } from "./AnswerCodeBlock";

--- a/packages/frontend/src/components/terminal/Prompt.tsx
+++ b/packages/frontend/src/components/terminal/Prompt.tsx
@@ -1,5 +1,5 @@
 import { prompt as promptStyle } from "./Terminal.css";
 
 export default function Prompt() {
-  return <span className={promptStyle}>$</span>;
+  return <span className={promptStyle}>&gt;&gt;</span>;
 }

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -36,13 +36,15 @@ export const prompt = style({
   position: "absolute",
   top: 1,
   left: 0,
+  color: color.$semantic.primary,
+  fontWeight: 700,
 });
 
 export const stdinContainer = style({ position: "relative" });
 
 export const stdin = style({
   display: "block",
-  textIndent: 16,
+  textIndent: 22,
 });
 
 export const commandInput = style({

--- a/packages/frontend/src/constants/path.ts
+++ b/packages/frontend/src/constants/path.ts
@@ -2,6 +2,7 @@ const BROWSWER_PATH = {
   MAIN: "/",
   QUIZZES: "/quizzes",
   SHARE: "/share",
+  NOT_FOUND: "/404",
 } as const;
 
 const API_PATH = {

--- a/packages/frontend/src/design-system/tokens/layout.css.ts
+++ b/packages/frontend/src/design-system/tokens/layout.css.ts
@@ -9,7 +9,7 @@ import {
   widthMax,
 } from "./utils.css";
 
-const headerHeight = "56px";
+export const headerHeight = "56px";
 const footerHeight = "250px";
 
 export const header = style([

--- a/packages/frontend/src/pages/share/[slug].page.tsx
+++ b/packages/frontend/src/pages/share/[slug].page.tsx
@@ -1,0 +1,84 @@
+import { isAxiosError } from "axios";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+
+import { GetSharedAnswerResponse, quizAPI } from "../../apis/quiz";
+import { AnswerCodeBlock, QuizContent } from "../../components/quiz";
+import { BROWSWER_PATH } from "../../constants/path";
+import { Button, toast } from "../../design-system/components/common";
+import { isString } from "../../utils/typeGuard";
+
+import * as styles from "./slug.css";
+
+export default function AnswerSharePage() {
+  const router = useRouter();
+  const {
+    query: { slug },
+  } = router;
+
+  const [sharedAnswer, setSharedAnswer] = useState<GetSharedAnswerResponse>();
+
+  const requestSharedAnswer = useCallback(
+    async (newSlug: string) => {
+      try {
+        const newSharedAnswer = await quizAPI.getSharedAnswer(newSlug);
+        setSharedAnswer(newSharedAnswer);
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 400) {
+          router.replace(BROWSWER_PATH.NOT_FOUND);
+          return;
+        }
+
+        toast.error("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요");
+      }
+    },
+    [router],
+  );
+
+  const handleLinkQuizPage = () => {
+    if (!sharedAnswer) {
+      return;
+    }
+
+    router.push(`${BROWSWER_PATH.QUIZZES}/${sharedAnswer.quiz.id}`);
+  };
+
+  useEffect(() => {
+    if (!isString(slug)) {
+      return;
+    }
+
+    requestSharedAnswer(slug);
+  }, [slug, requestSharedAnswer]);
+
+  if (!sharedAnswer) return null;
+
+  const {
+    answer,
+    quiz: { title, description, category },
+  } = sharedAnswer;
+  return (
+    <main className={styles.main}>
+      <section className={styles.quizContainer}>
+        <QuizContent
+          title={title}
+          description={description}
+          category={category}
+        />
+        <Button
+          variant="primaryFill"
+          full
+          onClick={handleLinkQuizPage}
+          className={styles.quizLinkButton}
+        >
+          문제 풀어보러 가기
+        </Button>
+      </section>
+      <section className={styles.answerContainer}>
+        <h2 className={styles.h2}>공유된 답안</h2>
+        <hr className={styles.hr} />
+        <AnswerCodeBlock answer={answer} />
+      </section>
+    </main>
+  );
+}

--- a/packages/frontend/src/pages/share/slug.css.ts
+++ b/packages/frontend/src/pages/share/slug.css.ts
@@ -1,0 +1,44 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../design-system/tokens/color";
+import { headerHeight } from "../../design-system/tokens/layout.css";
+import typography from "../../design-system/tokens/typography";
+import { border, flex } from "../../design-system/tokens/utils.css";
+
+export const main = style([flex, { height: `calc(93% - ${headerHeight})` }]);
+
+export const quizContainer = style([
+  border.all,
+  {
+    width: "40%",
+    borderTop: "none",
+    borderRight: "none",
+    padding: "33px 37px",
+  },
+]);
+
+export const quizLinkButton = style({ marginTop: 54 });
+
+export const answerContainer = style([
+  border.all,
+  {
+    flex: "1 0",
+    borderTop: "none",
+    padding: "47px 37px",
+  },
+]);
+
+export const h2 = style([
+  typography.$semantic.h2,
+  {
+    marginBottom: 16,
+    color: color.$scale.grey800,
+  },
+]);
+
+export const hr = style({
+  height: 1,
+  marginBottom: 54,
+  border: 0,
+  backgroundColor: color.$scale.grey300,
+});

--- a/packages/frontend/src/types/quiz.ts
+++ b/packages/frontend/src/types/quiz.ts
@@ -17,6 +17,8 @@ export type Quiz = {
   answer: string[];
 };
 
+export type SharedQuiz = Omit<Quiz, "answer">;
+
 export type Quizzes = {
   id: number;
   category: string;


### PR DESCRIPTION
close #221

## ✅ 작업 내용
- 공유 답안 페이지 스타일링 및 API 연결
- 터미널 프롬프트 스타일 변경
- 코드 블럭 컴포넌트화

## 📸 스크린샷
**공유 답안 페이지 > 문제 페이지 이동**
![shareAnswer page light](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/7208d8aa-9cbd-4021-898d-e5a21ff9115c)

**다크 모드**
<img width="1650" alt="shareAnswer dark" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/dff404c1-a8dd-41e4-b7d3-4d9342388ae2">

**터미널 프롬프트 스타일 변경**
|AS-IS|TO-BE|
|-|-|
|<img width="499" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/ecbc8007-e287-46c1-9b41-7e5d3ab64484">|<img width="574" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/1ee9234a-b824-4399-a844-08ae8a2b7875">|


## 📌 이슈 사항
- 디자인 상 공유 답안 코드 블럭에서 `git`에 하이라이팅이 되어야 하는데, API 응답에서 git 에 백틱 처리가 없어 아직 안 되고 있습니다. 용준님이 git 에 백틱처리해서 응답하는 걸로 변경하시면 하이라이팅 될 것 같습니다! <img width="552" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/bb952230-fa03-4aa2-8f24-cf583b561928">
- 잘못된 링크로 접근하면 API 통신하는 동안 사용자는 빈 화면을 보게 됩니다. 나중에 SSR을 적용해서 빈 화면 없이 404로 보내게 변경할까 합니다! ![shareAnswer 404](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/421139b5-662f-44e8-ba64-89670935ea13)

## 🟢 완료 조건
- 공유 답안 링크로 페이지에 접근할 수 있다.
- 잘못된 링크라면 404 페이지로 보낸다.
- 공유 답안에 해당하는 문제 페이지로 이동할 수 있다.
- 잘못된 링크가 아닌 API 응답일 시 토스트 메시지로 사용자에게 오류를 안내한다.

## ✍ 궁금한 점
- 레이아웃을 %로 설정하는 과정에서 헤더 높이가 필요해서 import하고 있는데 괜찮나요?
- 디자인은 버튼인데 클릭하면 다른 페이지로 이동하는 UI가 많아지고 있는 것 같습니다. `LinkButton`을 하나 만드는 건 어떤가요? 라우팅 처리 코드를 많이 제거할 수 있을 것 같아요!