### PR TITLE
[BE] feat#262 누락된 6번 문제 채점 로직 구현

### DIFF
--- a/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
+++ b/packages/backend/src/quiz-wizard/quiz-wizard.service.ts
@@ -57,7 +57,15 @@ index e69de29..3b18e51 100644
   }
 
   async checkCondition6(containerId: string): Promise<boolean> {
-    return (await this.magic.isBranchExist(containerId, 'dev')) === true;
+    if (
+      (await this.magic.getTreeHead(containerId, 'dev')) !==
+      '2c347f65f96ed5817553d668c062f8bec792131d'
+    )
+      return false;
+
+    if ((await this.magic.getNowBranch(containerId)) !== 'main') return false;
+
+    return true;
   }
 
   async checkCondition7(containerId: string): Promise<boolean> {

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -339,7 +339,12 @@ export class QuizzesController {
         await this.sessionService.getLogObject(sessionId, id)
       ).logs
         .filter((log) => log.mode === 'command')
-        .map((log) => log.message);
+        .map((log) => {
+          if (log.message.startsWith('git')) {
+            return log.message.replace('git', '`git`');
+          }
+          return log.message;
+        });
       const encodedCommands = encryptObject({
         id,
         commands,


### PR DESCRIPTION
close #262 

## ✅ 작업 내용

- 6번 문제 채점 로직 구현
  - dev 브랜치 커밋 헤드 트리 해쉬 확인
  - 현재 main브랜치인지 확인
- 문제 정답 시 git 에 앞 뒤로 백틱 추가

## 📌 이슈 사항

- 없습니다!

## 🟢 완료 조건

- 6번 문제 채점 가능
- 모든 테스트 케이스 통과

## ✍ 궁금한 점

- 없습니다!