### PR TITLE
[FE] fix#257 Graph 텍스트 갱신, 쌓임 순서 버그 수정

### DIFF
--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -37,6 +37,7 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
 
   // Add text next to each node
   svg
+    .select("#text")
     .selectAll("text")
     .data(treeData.descendants())
     .join(
@@ -65,6 +66,7 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
 
   // Draw edges (links) between nodes
   svg
+    .select("#link")
     .selectAll("line")
     .data([...treeData.links(), ...addedLine])
     .join(
@@ -83,6 +85,7 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
     .style("opacity", 1);
 
   svg
+    .select("#node")
     .selectAll("circle")
     .data(treeData.descendants())
     .join(
@@ -127,7 +130,11 @@ export function Graph({ className }: GraphProps) {
   return (
     <div className={className}>
       <svg width="100%">
-        <g ref={gRef} transform="translate(100,70)" />
+        <g ref={gRef} transform="translate(100,70)">
+          <g id="link" />
+          <g id="node" />
+          <g id="text" />
+        </g>
       </svg>
       <button type="button" onClick={handleNewData}>
         click

--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -40,14 +40,11 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
     .selectAll("text")
     .data(treeData.descendants())
     .join(
-      (enter) =>
-        enter
-          .append("text")
-          .style("opacity", 0)
-          .text((d) => d.data.message),
-      (update) => update.attr("x", (d) => d.x + 15).attr("y", (d) => d.y),
+      (enter) => enter.append("text").style("opacity", 0),
+      (update) => update,
       (exit) => exit.transition().duration(1000).style("opacity", 0).remove(),
     )
+    .text((d) => d.data.message)
     .attr("x", (d) => d.x + 20)
     .attr("y", (d) => d.y + 5)
     .transition()


### PR DESCRIPTION
close #257
close #258 

## ✅ 작업 내용
- Graph 텍스트 갱신이 제대로 되지 않는 문제 수정
  - d3 `join()` 메서드에서 데이터가 추가되었는데 갱신한 걸로, 데이터가 갱신되었는데 추가된 걸로 처리해서 데이터 변경 시에 텍스트가 제대로 갱신되지 않는 문제였습니다. 기존에 데이터가 추가될 때 텍스트를 작성했는데, 매번 작성하도록 수정했습니다.
- Graph 데이터 갱신 시 text, line, circle 쌓임 순서가 변경되는 문제
  - text, line, circle을 감싸는 g 태그를 만들어 SVG 요소를 새로 생성해도 HTML 상 순서가 바뀌지 않도록 했습니다.

## 📸 스크린샷
**텍스트 갱신**
|AS-IS|TO-BE|
|-|-|
|![graph bug asis](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/cf6f6747-99ab-42c6-8ec6-fd6458f33c21)|![graph bug tobe](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/416ea0b6-2d04-4951-9417-eb9e40431755)|


**데이터 갱신 시 쌓임 순서**

|AS-IS|TO-BE|
|-|-|
|<img width="677" alt="graph grouping before added" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/83c64e87-4103-415a-81b4-a51927ea7e89">|<img width="675" alt="graph grouping after added" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/7415d0c5-2005-450b-9e1a-80e2b501037b">|


## 📌 이슈 사항
- 데이터가 삭제될 때 라인 애니메이션이 어색한 것 같습니다..!

## 🟢 완료 조건
- 데이터가 변경될 때 텍스트 또한 갱신된다.
- 데이터가 변경되어도 text, line, circle간의 쌓임 순서가 변하지 않는다.

## ✍ 궁금한 점
- 없습니다!
