### PR TITLE
[FE] feat#179 다크 모드 지원

### DIFF
--- a/packages/frontend/src/design-system/components/common/Header/Header.css.ts
+++ b/packages/frontend/src/design-system/components/common/Header/Header.css.ts
@@ -10,6 +10,7 @@ export const container = style([
   widthMax,
   {
     height: "100%",
+    justifyContent: "space-between",
     margin: "0 auto",
     backgroundColor: color.$semantic.bgDefault,
   },

--- a/packages/frontend/src/design-system/components/common/Header/Header.tsx
+++ b/packages/frontend/src/design-system/components/common/Header/Header.tsx
@@ -1,23 +1,32 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { ColorTheme } from "../../../../hooks/useTheme";
 import classnames from "../../../../utils/classnames";
 import { header as headerLayout } from "../../../tokens/layout.css";
+import { useThemeContext } from "../Theme/ThemeContext";
+import ThemeSelect from "../Theme/ThemeSelect";
 
 import * as styles from "./Header.css";
 
 export default function Header() {
   const headerStyle = classnames(styles.borderBottom, headerLayout);
-  const logoSrc = "/light-logo.svg";
+  const { colorTheme } = useThemeContext();
+
+  const imgMap = {
+    light: "/light-logo.svg",
+    dark: "/dark-logo.svg",
+  }[colorTheme as ColorTheme];
 
   return (
     <header className={headerStyle}>
       <div className={styles.container}>
         <h1>
           <Link href="/">
-            <Image src={logoSrc} alt="Git Challenge" width={238} height={30} />
+            <Image src={imgMap} alt="Git Challenge" width={238} height={30} />
           </Link>
         </h1>
+        <ThemeSelect />
       </div>
     </header>
   );

--- a/packages/frontend/src/design-system/components/common/Theme/ThemeContext.ts
+++ b/packages/frontend/src/design-system/components/common/Theme/ThemeContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react";
+import * as React from "react";
+
+import useTheme from "../../../../hooks/useTheme";
+
+export type ThemeContextType = ReturnType<typeof useTheme>;
+
+const initialContext: ThemeContextType = {
+  colorTheme: "light",
+  setColorTheme: () => {},
+};
+
+export const ThemeContext = createContext<ThemeContextType>(initialContext);
+
+ThemeContext.displayName = "ThemeContext";
+
+export function useThemeContext(): ThemeContextType {
+  return React.useContext(ThemeContext);
+}

--- a/packages/frontend/src/design-system/components/common/Theme/ThemeSelect.css.ts
+++ b/packages/frontend/src/design-system/components/common/Theme/ThemeSelect.css.ts
@@ -1,0 +1,95 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../../tokens/color";
+import typography from "../../../tokens/typography";
+import {
+  border,
+  borderRadius,
+  flexAlignCenter,
+  flexCenter,
+  flexColumn,
+  widthFull,
+} from "../../../tokens/utils.css";
+
+const selectWidth = 106;
+const selectPadding = 10;
+const iconGap = 5;
+
+export const selectContainer = style([
+  {
+    position: "relative",
+    marginRight: 15,
+  },
+]);
+
+export const selectedItem = style([
+  flexAlignCenter,
+  {
+    gap: iconGap,
+  },
+]);
+
+export const select = style([
+  border.all,
+  borderRadius,
+  flexAlignCenter,
+  typography.$semantic.body2Regular,
+  {
+    justifyContent: "space-between",
+    width: selectWidth,
+    height: 36,
+    backgroundColor: color.$semantic.bgDefault,
+    color: color.$scale.grey700,
+    padding: selectPadding,
+    transition: "border 0.2s ease",
+    ":hover": {
+      border: `1px solid ${color.$scale.grey600}`,
+    },
+  },
+]);
+
+export const optionList = style([
+  flexColumn,
+  flexCenter,
+  border.all,
+  {
+    position: "absolute",
+    top: 40,
+    right: 0,
+    width: selectWidth,
+    backgroundColor: color.$scale.grey00,
+    borderRadius: "6px",
+    paddingInlineStart: 0,
+    padding: "6px 0px",
+    gap: "6px",
+  },
+]);
+
+export const option = style([
+  flexAlignCenter,
+  {
+    cursor: "pointer",
+    width: "90%",
+    height: "28px",
+    borderRadius: 4,
+    padding: 4,
+    ":hover": {
+      backgroundColor: color.$scale.grey50,
+    },
+  },
+]);
+
+export const optionButton = style([
+  flexAlignCenter,
+  widthFull,
+  typography.$semantic.body2Regular,
+  {
+    height: "100%",
+    padding: 0,
+    margin: 0,
+    color: color.$scale.grey700,
+    border: "none",
+    backgroundColor: "transparent",
+    gap: iconGap,
+  },
+]);

--- a/packages/frontend/src/design-system/components/common/Theme/ThemeSelect.tsx
+++ b/packages/frontend/src/design-system/components/common/Theme/ThemeSelect.tsx
@@ -1,0 +1,112 @@
+import type { MouseEvent } from "react";
+import { useEffect, useRef, useState } from "react";
+import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
+import { MdDarkMode, MdLightMode } from "react-icons/md";
+
+import { ESC_KEY } from "../../../../constants/event";
+
+import { useThemeContext } from "./ThemeContext";
+import * as styles from "./ThemeSelect.css";
+
+type ColorTheme = "light" | "dark";
+type StorageColorTheme = "light" | "dark" | undefined;
+
+function ThemeSelect() {
+  const { setColorTheme } = useThemeContext();
+  const [storageColorTheme, setStorageColorTheme] =
+    useState<ColorTheme>("light");
+  const [isOptionListOpen, setIsOptionListOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleOptionClick = (colorTheme: ColorTheme) => () => {
+    setStorageColorTheme(colorTheme);
+    setColorTheme(colorTheme);
+    handleSelectClick();
+  };
+
+  const handleSelectClick = () => {
+    setIsOptionListOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    const colorTheme = localStorage.getItem("colorTheme") as StorageColorTheme;
+    if (!colorTheme) {
+      setStorageColorTheme("light");
+      return;
+    }
+    setStorageColorTheme(colorTheme === "light" ? "light" : "dark");
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutSide = (e: MouseEvent<HTMLElement, MouseEvent>) => {
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setIsOptionListOpen(false);
+    };
+    const handleEscTyping = (e: KeyboardEvent) => {
+      if (e.key === ESC_KEY) setIsOptionListOpen(false);
+    };
+    document.addEventListener(
+      "mousedown",
+      handleClickOutSide as unknown as EventListener,
+    );
+    document.addEventListener("keydown", handleEscTyping);
+    return () => {
+      document.removeEventListener(
+        "mousedown",
+        handleClickOutSide as unknown as EventListener,
+      );
+      document.removeEventListener("keydown", handleEscTyping);
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className={styles.selectContainer}>
+      <button
+        type="button"
+        className={styles.select}
+        onClick={handleSelectClick}
+      >
+        <div className={styles.selectedItem}>
+          {OptionItem[storageColorTheme].render()}
+        </div>
+        {isOptionListOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}
+      </button>
+      {isOptionListOpen && (
+        <ul className={styles.optionList}>
+          {Object.entries(OptionItem).map(([key, value]) => (
+            <li key={key} className={styles.option}>
+              <button
+                type="button"
+                className={styles.optionButton}
+                onClick={handleOptionClick(key as ColorTheme)}
+              >
+                {value.render()}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default ThemeSelect;
+
+const OptionItem = {
+  light: {
+    render: () => (
+      <>
+        <MdLightMode />
+        <span>라이트</span>
+      </>
+    ),
+  },
+  dark: {
+    render: () => (
+      <>
+        <MdDarkMode />
+        <span>다크</span>
+      </>
+    ),
+  },
+};

--- a/packages/frontend/src/design-system/components/common/Theme/ThemeWrapper.tsx
+++ b/packages/frontend/src/design-system/components/common/Theme/ThemeWrapper.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from "react";
+
+import useTheme from "../../../../hooks/useTheme";
+
+import { ThemeContext } from "./ThemeContext";
+
+interface ThemeWrapperProps {
+  children: ReactElement;
+}
+
+export default function ThemeWrapper({ children }: ThemeWrapperProps) {
+  const theme = useTheme();
+
+  return (
+    <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  );
+}

--- a/packages/frontend/src/hooks/useTheme.ts
+++ b/packages/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type ColorTheme = "light" | "dark";
+
+export type ThemeContext = {
+  colorTheme: ColorTheme | undefined;
+  setColorTheme: (theme: ColorTheme) => void;
+};
+
+const ColorThemeStorageKey = "colorTheme";
+
+export default function useTheme() {
+  const [colorTheme, setColorTheme] = useState<ColorTheme | undefined>(
+    undefined,
+  );
+  const themeContext = useMemo<ThemeContext>(
+    () => ({ colorTheme, setColorTheme }),
+    [colorTheme],
+  );
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const color = localStorage.getItem(ColorThemeStorageKey);
+      setColorTheme(color ? (color as ColorTheme) : "light");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!colorTheme) return;
+    document.documentElement.dataset.theme = colorTheme;
+    localStorage.setItem(ColorThemeStorageKey, colorTheme);
+  }, [colorTheme]);
+
+  return themeContext;
+}

--- a/packages/frontend/src/pages/_app.page.tsx
+++ b/packages/frontend/src/pages/_app.page.tsx
@@ -8,6 +8,7 @@ import "react-toastify/dist/ReactToastify.min.css";
 
 import { ToastContainer } from "../design-system/components/common";
 import Layout from "../design-system/components/common/Layout";
+import ThemeWrapper from "../design-system/components/common/Theme/ThemeWrapper";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   import("../mocks");
@@ -24,10 +25,12 @@ export default function App({ Component, pageProps }: AppProps) {
             content="Git Challenge는 Git에 대한 문제를 실제 상황처럼 구현된 환경에서 학습할 수 있는 서비스입니다. 실제 프로젝트나 시나리오에서 발생할 수 있는 다양한 상황들을 경험하고 실전에서 해결할 수 있도록 도움을 드리는 것을 목표로 하고 있습니다."
           />
         </Head>
-        <Layout>
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Component {...pageProps} />
-        </Layout>
+        <ThemeWrapper>
+          <Layout>
+            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+            <Component {...pageProps} />
+          </Layout>
+        </ThemeWrapper>
       </React.StrictMode>
       <ToastContainer />
     </>


### PR DESCRIPTION
close #179 

## ✅ 작업 내용
- 라이트 모드/다크 모드 전환용 ThemeProvider, useTheme 구현

## 📸 스크린샷(FE만)
![Dec-08-2023 03-03-27](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/2e76d502-eed8-497a-9bc3-a4587bfb5db0)

- 로컬 스토리지에 테마가 없는 경우

![Dec-08-2023 04-11-47](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/8ea53c69-ffa8-4bae-976b-9f4ee902bc9e)

## 📌 이슈 사항
없습니다!

## 🟢 완료 조건
- 테마를 변경할 수 있다.

## ✍ 궁금한 점
- 조금 급하게 구현해서 코드가 읽기 어려울 수도 있습니다.. ㅠㅠ 편하게 질문/피드백 주세요!