### PR TITLE
[FE] feat#219 편집기 vi처럼 보이게 변경

### DIFF
--- a/packages/frontend/src/components/editor/Editor.css.ts
+++ b/packages/frontend/src/components/editor/Editor.css.ts
@@ -52,6 +52,12 @@ export const input = style([
     backgroundColor: color.$semantic.bgDefault,
     color: color.$scale.grey900,
     outline: "none",
+
+    selectors: {
+      "&.error": {
+        color: color.$semantic.danger,
+      },
+    },
   },
 ]);
 

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -1,12 +1,12 @@
 import {
   ChangeEventHandler,
   KeyboardEventHandler,
-  RefObject,
   useRef,
   useState,
 } from "react";
 
 import { ENTER_KEY, ESC_KEY } from "../../constants/event";
+import { createClassManipulator } from "../../utils/classList";
 
 import * as styles from "./Editor.css";
 
@@ -158,12 +158,4 @@ function isCommandMode(mode: ModeType) {
 
 function isInsertMode(mode: ModeType) {
   return !isCommandMode(mode);
-}
-
-function createClassManipulator<T extends Element>(
-  ref: RefObject<T>,
-  className: string,
-) {
-  return (action: "add" | "remove") =>
-    ref.current?.classList[action](className);
 }

--- a/packages/frontend/src/components/editor/Editor.tsx
+++ b/packages/frontend/src/components/editor/Editor.tsx
@@ -1,6 +1,7 @@
 import {
   ChangeEventHandler,
   KeyboardEventHandler,
+  RefObject,
   useRef,
   useState,
 } from "react";
@@ -10,6 +11,8 @@ import { ENTER_KEY, ESC_KEY } from "../../constants/event";
 import * as styles from "./Editor.css";
 
 type ModeType = "insert" | "command";
+
+const ERROR_CLASS_NAME = "error";
 
 export interface EditorProps {
   initialFile: string;
@@ -24,7 +27,13 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const manipulateErrorClass = createClassManipulator(
+    inputRef,
+    ERROR_CLASS_NAME,
+  );
+
   const toCommandMode = (nextInputValue: string) => {
+    manipulateErrorClass("remove");
     setMode("command");
     setInputValue(nextInputValue);
     setInputReadonly(true);
@@ -90,6 +99,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
         if (changedFile) {
           event.preventDefault();
           toCommandMode("E37: No write since last change (add ! to override)");
+          manipulateErrorClass("add");
           return;
         }
         onSubmit(initialFile);
@@ -108,6 +118,7 @@ export function Editor({ initialFile, onSubmit }: EditorProps) {
 
       event.preventDefault();
       toCommandMode(`E492: Not an editor command: ${value.substring(1)}`);
+      manipulateErrorClass("add");
     }
   };
 
@@ -147,4 +158,12 @@ function isCommandMode(mode: ModeType) {
 
 function isInsertMode(mode: ModeType) {
   return !isCommandMode(mode);
+}
+
+function createClassManipulator<T extends Element>(
+  ref: RefObject<T>,
+  className: string,
+) {
+  return (action: "add" | "remove") =>
+    ref.current?.classList[action](className);
 }

--- a/packages/frontend/src/components/quiz/SolvedModal/SolvedModal.tsx
+++ b/packages/frontend/src/components/quiz/SolvedModal/SolvedModal.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   toast,
 } from "../../../design-system/components/common";
+import { createClassManipulator } from "../../../utils/classList";
 
 import * as styles from "./SolvedModal.css";
 
@@ -27,14 +28,15 @@ export function SolvedModal({
   onNextQuiz,
 }: SolvedModalProps) {
   const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const manipulateVisibleClass = createClassManipulator(copyButtonRef, VISIBLE);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(link);
-      copyButtonRef.current?.classList.add(VISIBLE);
+      manipulateVisibleClass("add");
 
       setTimeout(() => {
-        copyButtonRef.current?.classList.remove(VISIBLE);
+        manipulateVisibleClass("remove");
       }, COPY_SUCCESS_DURATION);
     } catch (error) {
       toast.error("링크 복사를 실패했습니다. 잠시 후 다시 시도해 주세요.");

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -20,6 +20,7 @@ import {
   terminalReducer,
 } from "../../reducers/terminalReducer";
 import { Categories, Quiz, QuizGitGraphCommit } from "../../types/quiz";
+import { TerminalContentType } from "../../types/terminalType";
 import { scrollIntoView } from "../../utils/scroll";
 import { isString } from "../../utils/typeGuard";
 
@@ -150,7 +151,9 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
             ref={barRef}
             aria-label="divider"
             onMouseDown={handleBarHover}
-          />
+          >
+            {getTerminalInfo({ terminalMode, contentArray })}
+          </div>
           {isEditorMode(terminalMode) ? (
             <Editor initialFile={editorFile} onSubmit={handleTerminal} />
           ) : (
@@ -236,4 +239,24 @@ function handleResponseError(
   }
 
   toast.error("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요");
+}
+
+function getTerminalInfo({
+  terminalMode,
+  contentArray,
+}: {
+  terminalMode: "command" | "editor";
+  contentArray: TerminalContentType[];
+}) {
+  const VI = "vi";
+  const EDITOR_REDIRECTION = " ◀ ";
+
+  return isEditorMode(terminalMode)
+    ? [VI, getCommandOpenEditor(contentArray)].join(EDITOR_REDIRECTION)
+    : "";
+}
+
+function getCommandOpenEditor(contentArray: TerminalContentType[]) {
+  const index = contentArray.findLastIndex(({ type }) => type === "stdin");
+  return index < 0 ? "" : contentArray[index].content;
 }

--- a/packages/frontend/src/pages/quizzes/quiz.css.ts
+++ b/packages/frontend/src/pages/quizzes/quiz.css.ts
@@ -1,6 +1,7 @@
 import { style } from "@vanilla-extract/css";
 
 import color from "../../design-system/tokens/color";
+import typography from "../../design-system/tokens/typography";
 import {
   border,
   flex,
@@ -12,11 +13,14 @@ import {
 export const bar = style([
   middleLayer,
   border.all,
+  typography.$semantic.code,
   {
     position: "relative",
     minHeight: 20,
     borderBottom: "none",
+    color: color.$scale.grey600,
     backgroundColor: color.$scale.grey100,
+    textAlign: "center",
     cursor: "row-resize",
 
     "::before": {

--- a/packages/frontend/src/utils/classList.ts
+++ b/packages/frontend/src/utils/classList.ts
@@ -1,0 +1,9 @@
+import { RefObject } from "react";
+
+export function createClassManipulator<T extends Element>(
+  ref: RefObject<T>,
+  className: string,
+) {
+  return (action: "add" | "remove") =>
+    ref.current?.classList[action](className);
+}


### PR DESCRIPTION
close #219 

## ✅ 작업 내용
- 상단 바에 편집기를 연 명령어와 vi 텍스트 표시
- 편집기 에러 메시지 색상 표시

## 📸 스크린샷
|light|dark|
|-|-|
|<img width="1043" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/417b04e4-8a6d-4274-8125-b85787a46cfd">|<img width="1041" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/58e14e62-19b3-441b-8b9e-38a6faf80bd4">|


## 📌 이슈 사항
- 상단 바에 표시되는 텍스트와 에러 메시지 스타일링이 실제 vi 와 다릅니다. 
  - 원래 상단 바에 "폴더 경로 - 명령어 - vi - vi를 실행한 명령어" 로 표시되는데, 폴더 이동 명령어를 지원하지 않아서 안 보여줘도 될 것 같고 "vi - vi를 실행한 명령어" 만으로 충분한 것 같아 다르게 했습니다.
  - vi 처럼 배경색을 빨갛게 하면, 아래처럼 텍스트 너비만큼이 아닌 Editor > input 요소 너비만큼 채워져서 에러 느낌이 너무 강합니다..

|vi|vi처럼 에러 메시지 스타일링|
|-|-|
|<img width="677" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/c19cc39b-e71f-45f0-b61e-2c129f49b0a6">|<img width="1040" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/c58d597c-e505-4abc-96e2-4eef3a88108f">|

## 🟢 완료 조건
- 편집기가 열리면, 상단에 vi 와 편집기를 실행한 명령어가 보인다.
- 편집기에 에러 메시지가 빨갛게 보인다. 

## ✍ 궁금한 점
- 없습니다!