### PR TITLE
[BE] fix#285 editor 시 컨테이너 복구하는 로직 삭제

### DIFF
--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -246,21 +246,16 @@ export class ContainersService {
 
     let recentMessage = '';
 
-    const commands = logs.reduce((acc, log, index, array) => {
+    const commands: string[] = logs.map((log) => {
       if (log.mode === 'command') {
         recentMessage = log.message;
-        if (array[index + 1] && array[index + 1].mode === 'editor') {
-          return acc;
-        }
-        acc.push(log.message);
+        return log.message;
       } else if (log.mode === 'editor') {
-        acc.push(this.buildEditorCommand(log.message, recentMessage));
+        return this.buildEditorCommand(log.message, recentMessage);
       } else {
         throw new Error('Invalid log mode');
       }
-
-      return acc;
-    }, []);
+    });
 
     await this.commandService.executeCommand(
       this.buildDockerCommand(containerId, ...commands),

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -82,7 +82,7 @@ export class ContainersService {
   private buildEditorCommand(message: string, command: string) {
     const escapedMessage = shellEscape([message]);
 
-    return `git config --global core.editor /editor/input.sh; echo ${escapedMessage} | ${command}`;
+    return `git config core.editor --global /editor/input.sh; echo ${escapedMessage} | ${command}`;
   }
 
   private getEditorCommand(
@@ -138,6 +138,7 @@ export class ContainersService {
     const chownOriginCommand = `[ -d ~/origins/${quizId} ] && docker exec -u root ${containerId} chown -R ${user}:${user} /origin`;
     const chownUpstreamCommand = `[ -d ~/upstreams/${quizId} ] && docker exec -u root ${containerId} chown -R ${user}:${user} /remote`;
     const coreEditorCommand = `docker exec -w /home/quizzer/quiz/ -u ${user} ${containerId} git config --global core.editor /editor/output.sh`;
+    const mainBranchCommand = `docker exec -w /home/quizzer/quiz/ -u ${user} ${containerId} git config --global init.defaultbranch main`;
     const containerDirectoryCommand = `mkdir /root/store/${containerId}`;
     const containerDirectoryCpCommand = `docker cp ${containerId}:/home/quizzer/quiz/. /root/store/${containerId}/`;
     await this.commandService.executeCommand(
@@ -149,6 +150,7 @@ export class ContainersService {
       chownOriginCommand,
       chownUpstreamCommand,
       coreEditorCommand,
+      mainBranchCommand,
       containerDirectoryCommand,
       containerDirectoryCpCommand,
     );
@@ -262,21 +264,6 @@ export class ContainersService {
 
     await this.commandService.executeCommand(
       this.buildDockerCommand(containerId, ...commands),
-    );
-  }
-
-  async stashContainer(container: string): Promise<void> {
-    this.commandService.executeCommand(
-      `rm -rf /root/store/${container}/.`,
-      `docker cp ${container}:/home/quizzer/quiz/. /root/store/${container}/`,
-    );
-  }
-
-  async stashApplyContainer(container: string): Promise<void> {
-    this.commandService.executeCommand(
-      `docker exec -u quizzer -w /home/quizzer/ ${container} rm -rf quiz/.`,
-      `docker cp /root/store/${container}/. ${container}:/home/quizzer/quiz/.`,
-      `docker exec -u root ${container} chown -R quizzer:quizzer /home/quizzer`,
     );
   }
 }

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -82,7 +82,7 @@ export class ContainersService {
   private buildEditorCommand(message: string, command: string) {
     const escapedMessage = shellEscape([message]);
 
-    return `git config core.editor --global /editor/input.sh; echo ${escapedMessage} | ${command}`;
+    return `git config --global core.editor /editor/input.sh; echo ${escapedMessage} | ${command}`;
   }
 
   private getEditorCommand(

--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -170,21 +170,6 @@ export class QuizzesController {
           containerId,
           execCommandDto.message,
         ));
-
-        if (result === MODE.EDITOR) {
-          this.containerService.stashApplyContainer(containerId);
-          // containerId = await this.containerService.getContainer(id);
-          // await this.sessionService.setContainerBySessionId(
-          //   sessionId,
-          //   id,
-          //   containerId,
-          // );
-          // this.containerService.restoreContainer(
-          //   await this.sessionService.getLogObject(sessionId, id),
-          // );
-        } else {
-          this.containerService.stashContainer(containerId);
-        }
       } else if (execCommandDto.mode === MODE.EDITOR) {
         // editor mode
         const { mode: recentMode, message: recentMessage } =
@@ -223,7 +208,7 @@ export class QuizzesController {
       this.sessionService.pushLogBySessionId(execCommandDto, sessionId, id);
 
       if (
-        result !== MODE.EDITOR ||
+        result !== MODE.EDITOR &&
         (await this.sessionService.isGraphUpdated(sessionId, id, graph))
       ) {
         await this.sessionService.updateGraph(sessionId, id, graph);


### PR DESCRIPTION
close #285

## ✅ 작업 내용

- stash, stashpop 등 복구 로직 삭제
- quizzer에 대해서 defaultbranch가 master이던 버그 수정
- --global 설정이 일관적으로 사용되도록 적용
- && 버그 수정

## 📌 이슈 사항

- 현재 "" 관련 버그 있어요. 다음 PR 때 수정할 계획입니다. (git commit -m "입력1 입력2" 하면 ""파싱 때문인지 입력1만 커밋 메시지로 인정됨) sh -c 와 관련 있을 것으로 예상합니다.

## 🟢 완료 조건

- 모든 테스트 케이스 통과 (""케이스 제외)
- 복구 로직 삭제해도 기능 작동

## ✍ 궁금한 점

- 없습니다!