### PR TITLE
[FE] feat#252 사용자 정답 기록 상태 관리

### DIFF
--- a/packages/frontend/src/apis/session.ts
+++ b/packages/frontend/src/apis/session.ts
@@ -1,0 +1,13 @@
+import { API_PATH } from "../constants/path";
+import { UserQuizStatus } from "../types/user";
+
+import { instance } from "./base";
+
+export const sessionAPI = {
+  getSolved: async () => {
+    const { data } = await instance.get<UserQuizStatus>(
+      `${API_PATH.SESSION}/solved`,
+    );
+    return data;
+  },
+};

--- a/packages/frontend/src/apis/session.ts
+++ b/packages/frontend/src/apis/session.ts
@@ -4,7 +4,7 @@ import { UserQuizStatus } from "../types/user";
 import { instance } from "./base";
 
 export const sessionAPI = {
-  getSolved: async () => {
+  getUserQuizStatus: async () => {
     const { data } = await instance.get<UserQuizStatus>(
       `${API_PATH.SESSION}/solved`,
     );

--- a/packages/frontend/src/constants/path.ts
+++ b/packages/frontend/src/constants/path.ts
@@ -7,6 +7,7 @@ const BROWSWER_PATH = {
 
 const API_PATH = {
   QUIZZES: "/quizzes",
+  SESSION: "/session",
 } as const;
 
 const GIT_BOOK_URL = "https://git-scm.com/docs/git";

--- a/packages/frontend/src/contexts/UserQuizStatusContext/UserQuizStatusContext.tsx
+++ b/packages/frontend/src/contexts/UserQuizStatusContext/UserQuizStatusContext.tsx
@@ -1,0 +1,78 @@
+import {
+  type Dispatch,
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useReducer,
+} from "react";
+
+import { UserQuizStatus } from "../../types/user";
+import { objectKeys } from "../../utils/types";
+
+import { Action, UserQuizStatusActionType } from "./type";
+
+const UserQuizStatusContext = createContext<UserQuizStatus>({});
+const UserQuizStatusDispatchContext = createContext<Dispatch<Action>>(() => {});
+
+interface UserQuizStatusProviderProps {
+  initialUserQuizStatus: UserQuizStatus;
+  children: ReactNode;
+}
+
+export function UserQuizStatusProvider({
+  initialUserQuizStatus,
+  children,
+}: UserQuizStatusProviderProps) {
+  const [userQuizStatus, dispatch] = useReducer(reducer, initialUserQuizStatus);
+
+  useEffect(() => {
+    dispatch({
+      type: UserQuizStatusActionType.Initialize,
+      data: initialUserQuizStatus,
+    });
+  }, [initialUserQuizStatus]);
+
+  return (
+    <UserQuizStatusContext.Provider value={userQuizStatus}>
+      <UserQuizStatusDispatchContext.Provider value={dispatch}>
+        {children}
+      </UserQuizStatusDispatchContext.Provider>
+    </UserQuizStatusContext.Provider>
+  );
+}
+
+export function useUserQuizStatus() {
+  const userQuizStatus = useContext(UserQuizStatusContext);
+  if (!userQuizStatus) {
+    throw new Error("UserQuizStatusProvider 컴포넌트로 래핑해야 합니다.");
+  }
+  return userQuizStatus;
+}
+
+export function useUserQuizStatusDispatch() {
+  const dispatch = useContext(UserQuizStatusDispatchContext);
+  if (!dispatch) {
+    throw new Error("UserQuizStatusProvider 컴포넌트로 래핑해야 합니다.");
+  }
+  return dispatch;
+}
+
+function reducer(state: UserQuizStatus, action: Action): UserQuizStatus {
+  switch (action.type) {
+    case UserQuizStatusActionType.Initialize:
+      return action.data;
+
+    case UserQuizStatusActionType.Reset:
+      return Object.fromEntries(objectKeys(state).map((key) => [key, false]));
+
+    case UserQuizStatusActionType.ResetQuizById:
+      return { ...state, [action.id]: false };
+
+    case UserQuizStatusActionType.SolveQuizById:
+      return { ...state, [action.id]: true };
+
+    default:
+      throw new Error(`${action} not supported`);
+  }
+}

--- a/packages/frontend/src/contexts/UserQuizStatusContext/UserQuizStatusContext.tsx
+++ b/packages/frontend/src/contexts/UserQuizStatusContext/UserQuizStatusContext.tsx
@@ -51,11 +51,11 @@ export function useUserQuizStatus() {
 }
 
 export function useUserQuizStatusDispatch() {
-  const dispatch = useContext(UserQuizStatusDispatchContext);
-  if (!dispatch) {
+  const userQuizStatusDispatch = useContext(UserQuizStatusDispatchContext);
+  if (!userQuizStatusDispatch) {
     throw new Error("UserQuizStatusProvider 컴포넌트로 래핑해야 합니다.");
   }
-  return dispatch;
+  return userQuizStatusDispatch;
 }
 
 function reducer(state: UserQuizStatus, action: Action): UserQuizStatus {

--- a/packages/frontend/src/contexts/UserQuizStatusContext/index.ts
+++ b/packages/frontend/src/contexts/UserQuizStatusContext/index.ts
@@ -1,0 +1,6 @@
+export { UserQuizStatusActionType } from "./type";
+export {
+  UserQuizStatusProvider,
+  useUserQuizStatus,
+  useUserQuizStatusDispatch,
+} from "./UserQuizStatusContext";

--- a/packages/frontend/src/contexts/UserQuizStatusContext/type.ts
+++ b/packages/frontend/src/contexts/UserQuizStatusContext/type.ts
@@ -1,0 +1,33 @@
+import { UserQuizStatus } from "../../types/user";
+
+export enum UserQuizStatusActionType {
+  Initialize,
+  Reset,
+  ResetQuizById,
+  SolveQuizById,
+}
+
+export type Action =
+  | InitializeAction
+  | ResetAction
+  | ResetQuizByIdAction
+  | SolveQuizByIdAction;
+
+type InitializeAction = {
+  type: UserQuizStatusActionType.Initialize;
+  data: UserQuizStatus;
+};
+
+type ResetAction = {
+  type: UserQuizStatusActionType.Reset;
+};
+
+type ResetQuizByIdAction = {
+  type: UserQuizStatusActionType.ResetQuizById;
+  id: number;
+};
+
+type SolveQuizByIdAction = {
+  type: UserQuizStatusActionType.SolveQuizById;
+  id: number;
+};

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
@@ -26,7 +26,13 @@ export const linkItemStyle = style({
 export const baseLinkStyle = style([
   flexAlignCenter,
   typography.$semantic.title4Regular,
-  { width: "100%", height: "100%", paddingLeft: 15, textDecoration: "none" },
+  {
+    width: "100%",
+    height: "100%",
+    paddingLeft: 15,
+    textDecoration: "none",
+    gap: 2,
+  },
 ]);
 
 export const currentLinkStyle = style([
@@ -42,3 +48,7 @@ export const linkStyle = style([
     color: color.$scale.grey600,
   },
 ]);
+
+export const checkIcon = style({
+  color: color.$semantic.success,
+});

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
@@ -19,7 +19,7 @@ export default function SideBar() {
         <Accordion key={item.title} open>
           <Accordion.Details>
             <Accordion.Summary>{item.title}</Accordion.Summary>
-            <SubItems subItems={item.subItems} />
+            <SubTitleList subItems={item.subItems} />
           </Accordion.Details>
         </Accordion>
       ))}
@@ -27,12 +27,14 @@ export default function SideBar() {
   );
 }
 
-interface SubItemsProps {
-  id?: number;
-  subTitle: string;
+interface SubTitleListProps {
+  subItems: {
+    id: number;
+    subTitle: string;
+  }[];
 }
 
-function SubItems({ subItems }: { subItems: SubItemsProps[] }) {
+function SubTitleList({ subItems }: SubTitleListProps) {
   const {
     query: { id },
   } = useRouter();
@@ -42,24 +44,36 @@ function SubItems({ subItems }: { subItems: SubItemsProps[] }) {
 
   return (
     <ol className={styles.linkContainerStyle}>
-      {subItems.map((subTitle) => (
-        <li
-          className={styles.linkItemStyle}
-          key={[subTitle.subTitle, subTitle?.id].join("")}
-        >
-          <Link
-            href={`${BROWSWER_PATH.QUIZZES}/${subTitle.id}`}
-            className={
-              idNum === subTitle.id ? styles.currentLinkStyle : styles.linkStyle
-            }
-          >
-            {subTitle.subTitle}
-            {userQuizStatus[subTitle.id ?? ""] && (
-              <IoMdCheckmark className={styles.checkIcon} size={14} />
-            )}
-          </Link>
-        </li>
+      {subItems.map(({ subTitle, id: subItemId }) => (
+        <SubTitleItem
+          key={subItemId}
+          subTitle={subTitle}
+          id={subItemId ?? 0}
+          current={idNum === subItemId}
+          solved={userQuizStatus[subItemId ?? 0] ?? false}
+        />
       ))}
     </ol>
+  );
+}
+
+interface SubTitleItemProps {
+  id: number;
+  subTitle: string;
+  current: boolean;
+  solved: boolean;
+}
+
+function SubTitleItem({ subTitle, id, current, solved }: SubTitleItemProps) {
+  return (
+    <li className={styles.linkItemStyle} key={[subTitle, id].join("")}>
+      <Link
+        href={`${BROWSWER_PATH.QUIZZES}/${id}`}
+        className={current ? styles.currentLinkStyle : styles.linkStyle}
+      >
+        {subTitle}
+        {solved && <IoMdCheckmark className={styles.checkIcon} size={14} />}
+      </Link>
+    </li>
   );
 }

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { IoMdCheckmark } from "react-icons/io";
 
 import { BROWSWER_PATH } from "../../../../constants/path";
+import { useUserQuizStatus } from "../../../../contexts/UserQuizStatusContext";
 import * as layout from "../../../tokens/layout.css";
 import { Accordion } from "../Accordion";
 
@@ -34,6 +36,8 @@ function SubItems({ subItems }: { subItems: SubItemsProps[] }) {
   const {
     query: { id },
   } = useRouter();
+  const userQuizStatus = useUserQuizStatus();
+
   const idNum = id ? +id : 0;
 
   return (
@@ -50,6 +54,9 @@ function SubItems({ subItems }: { subItems: SubItemsProps[] }) {
             }
           >
             {subTitle.subTitle}
+            {userQuizStatus[subTitle.id ?? ""] && (
+              <IoMdCheckmark className={styles.checkIcon} size={14} />
+            )}
           </Link>
         </li>
       ))}

--- a/packages/frontend/src/pages/_app.page.tsx
+++ b/packages/frontend/src/pages/_app.page.tsx
@@ -2,20 +2,35 @@ import "../design-system/styles/global.css";
 
 import type { AppProps } from "next/app";
 import Head from "next/head";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import "react-toastify/dist/ReactToastify.min.css";
 
+import { sessionAPI } from "../apis/session";
 import { UserQuizStatusProvider } from "../contexts/UserQuizStatusContext";
-import { ToastContainer } from "../design-system/components/common";
+import { ToastContainer, toast } from "../design-system/components/common";
 import Layout from "../design-system/components/common/Layout";
 import ThemeWrapper from "../design-system/components/common/Theme/ThemeWrapper";
+import { UserQuizStatus } from "../types/user";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   import("../mocks");
 }
 
 export default function App({ Component, pageProps }: AppProps) {
+  const [userQuizStatus, setUserQuizStatus] = useState<UserQuizStatus>({});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const nextUserQuizStatus = await sessionAPI.getSolved();
+        setUserQuizStatus(nextUserQuizStatus);
+      } catch (error) {
+        toast.error("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요");
+      }
+    })();
+  }, []);
+
   return (
     <>
       <React.StrictMode>
@@ -26,7 +41,7 @@ export default function App({ Component, pageProps }: AppProps) {
             content="Git Challenge는 Git에 대한 문제를 실제 상황처럼 구현된 환경에서 학습할 수 있는 서비스입니다. 실제 프로젝트나 시나리오에서 발생할 수 있는 다양한 상황들을 경험하고 실전에서 해결할 수 있도록 도움을 드리는 것을 목표로 하고 있습니다."
           />
         </Head>
-        <UserQuizStatusProvider initialUserQuizStatus={{}}>
+        <UserQuizStatusProvider initialUserQuizStatus={userQuizStatus}>
           <ThemeWrapper>
             <Layout>
               {/* eslint-disable-next-line react/jsx-props-no-spreading */}

--- a/packages/frontend/src/pages/_app.page.tsx
+++ b/packages/frontend/src/pages/_app.page.tsx
@@ -23,7 +23,7 @@ export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     (async () => {
       try {
-        const nextUserQuizStatus = await sessionAPI.getSolved();
+        const nextUserQuizStatus = await sessionAPI.getUserQuizStatus();
         setUserQuizStatus(nextUserQuizStatus);
       } catch (error) {
         toast.error("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요");

--- a/packages/frontend/src/pages/_app.page.tsx
+++ b/packages/frontend/src/pages/_app.page.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import "react-toastify/dist/ReactToastify.min.css";
 
+import { UserQuizStatusProvider } from "../contexts/UserQuizStatusContext";
 import { ToastContainer } from "../design-system/components/common";
 import Layout from "../design-system/components/common/Layout";
 import ThemeWrapper from "../design-system/components/common/Theme/ThemeWrapper";
@@ -25,12 +26,14 @@ export default function App({ Component, pageProps }: AppProps) {
             content="Git Challenge는 Git에 대한 문제를 실제 상황처럼 구현된 환경에서 학습할 수 있는 서비스입니다. 실제 프로젝트나 시나리오에서 발생할 수 있는 다양한 상황들을 경험하고 실전에서 해결할 수 있도록 도움을 드리는 것을 목표로 하고 있습니다."
           />
         </Head>
-        <ThemeWrapper>
-          <Layout>
-            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <Component {...pageProps} />
-          </Layout>
-        </ThemeWrapper>
+        <UserQuizStatusProvider initialUserQuizStatus={{}}>
+          <ThemeWrapper>
+            <Layout>
+              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+              <Component {...pageProps} />
+            </Layout>
+          </ThemeWrapper>
+        </UserQuizStatusProvider>
       </React.StrictMode>
       <ToastContainer />
     </>

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -83,10 +83,16 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
       return;
     }
 
+    const numId = +id;
+
     try {
-      const response = await quizAPI.submit(+id);
+      const response = await quizAPI.submit(numId);
       if (response.solved) {
         const shareLink = `${process.env.NEXT_PUBLIC_BASE_URL}${BROWSWER_PATH.SHARE}/${response.slug}`;
+        userQuizStatusDispatcher({
+          type: UserQuizStatusActionType.SolveQuizById,
+          id: numId,
+        });
         solvedModal.onSolved(shareLink);
         return;
       }

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -11,6 +11,10 @@ import { SolvedModal, useSolvedModal } from "../../components/quiz";
 import { QuizGuide } from "../../components/quiz/QuizGuide";
 import { Terminal } from "../../components/terminal";
 import { BROWSWER_PATH } from "../../constants/path";
+import {
+  UserQuizStatusActionType,
+  useUserQuizStatusDispatch,
+} from "../../contexts/UserQuizStatusContext";
 import { Button, toast } from "../../design-system/components/common";
 import useResizableSplitView from "../../hooks/useResizableSplitView";
 import {
@@ -33,6 +37,7 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
   } = router;
 
   const [gitGraphData, setGitGraphData] = useState<QuizGitGraphCommit[]>([]);
+  const userQuizStatusDispatcher = useUserQuizStatusDispatch();
 
   const solvedModal = useSolvedModal(isString(id) ? +id : -1);
   const [{ terminalMode, editorFile, contentArray }, terminalDispatch] =
@@ -113,6 +118,10 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
       terminalDispatch({ type: TerminalActionTypes.reset });
       clearTextContent(terminalInputRef);
       focusRef(terminalInputRef);
+      userQuizStatusDispatcher({
+        type: UserQuizStatusActionType.ResetQuizById,
+        id: numId,
+      });
       toast.success("문제가 성공적으로 초기화되었습니다!");
     } catch (error) {
       toast.error(

--- a/packages/frontend/src/types/user.ts
+++ b/packages/frontend/src/types/user.ts
@@ -1,0 +1,3 @@
+export type UserQuizStatus = {
+  [quizId: string]: boolean;
+};


### PR DESCRIPTION
close #252

## ✅ 작업 내용
- 사용자 정답 기록 context 구현
- 사이드바에 맞춘 문제 표시
- 문제 초기화/채점 API 응답에 맞게 사용자 정답 기록 context 업데이트 

## 📸 스크린샷
**문제 채점 > 문제 초기화 > 문제 채점 > 새로고침 순으로 테스트**
![user quiz status ](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/b16d59ba-f0d6-42a0-819f-e7b835fd86a4)

## 📌 이슈 사항
- 새로고침하면 이미 사이드바가 렌더링된 상태(SSG)에서 정답 기록 조회 API 를 요청하기 때문에 한박자 느리게 표시됩니다..
- Sidebar > SubTitleList 에서 사용자 정답 기록 context를 사용하고 있습니다. context가 변경되면 SubTitleList가 모두 렌더링되길래 `React.memo`로 메모이제이션 해봤는데 렌더링 시간 차이가 1ms 이하이길래 제거했습니다..! (아래 그림은 각각 1번 문제를 맞춘 상태에서 초기화했을 때 profile 결과입니다.)

|메모이제이션 전|메모이제이션 후|
|-|-|
|![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/da4dc546-ba4e-4f9b-bab3-9781444d3c30)|![image](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/fa0925bc-a8e9-4191-8c25-5423d2ed5e3f)|



## 🟢 완료 조건
- 사용자는 사이드바에서 체크 표시로 자신이 맞춘 문제를 확인할 수 있다.
- 맞춘 문제를 초기화하면 사이드바에서 체크 표시가 사라진다.
- 문제를 맞추면 사이드바에서 체크 표시가 생긴다.

## ✍ 궁금한 점
- 변수명이 너무 긴가요..?
- Next.js 앱 실행 시 한 번만 사용자 정답 기록 조회 API를 요청하고 전역 상태로 관리해야 해서, app에서 API 통신을 합니다. app 코드는 최대한 간결하게 가져가야 할 것 같은데 api 처리하는 로직을 훅으로 뺄까요?