### PR TITLE
[BE] feat#290 그래프가 없더라도 상황에 맞는 ref값을 제공한다

### DIFF
--- a/packages/backend/src/quizzes/quizzes.controller.ts
+++ b/packages/backend/src/quizzes/quizzes.controller.ts
@@ -471,7 +471,7 @@ export class QuizzesController {
         ref: defaultRef,
       };
     }
-    if (!graph) {
+    if (await this.sessionService.isReseted(sessionId, id)) {
       return {
         ...defaultGraph,
         ref: defaultRef,

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -108,6 +108,7 @@ export class SessionService {
     session.problems.get(problemId).status = 'solving';
     session.problems.get(problemId).graph = '';
     session.problems.get(problemId).containerId = '';
+    session.problems.get(problemId).ref = '';
   }
 
   private async getSessionById(id: string): Promise<Session> {
@@ -234,5 +235,13 @@ export class SessionService {
       );
     }
     return;
+  }
+
+  async isReseted(sessionId: string, problemId: number): Promise<boolean> {
+    const session = await this.getSessionById(sessionId);
+    if (!session.problems.get(problemId)) {
+      throw new Error('problem not found');
+    }
+    return session.problems.get(problemId).logs.length === 0;
   }
 }


### PR DESCRIPTION
close #290

## ✅ 작업 내용
- 초기화 상태인지 검사하는 함수 추가
- 초기화 할때 ref값도 같이 초기화한다
- 초기화 상태가 아니라면 세션에 있는 ref값을 제공한다

## 📌 이슈 사항
- 기존에 그래프 유무로 ref값을 제공하던 분기를, 초기상태인지 검사해서 초기상태일때만 default값 제공하도록 변경했습니다!
- 기존에 초기화 할떄 ref값은 초기화 안되던 버그를 발견해서 고쳤습니다!
  - 이부분은 좀 유동성있게 짜둘껄 그랬어요 지난번에도 여기 유동성 있게 바꾸려다가 버그 생겨서 고쳤었어요

## 🟢 완료 조건
- [x] 그래프가 없더라도 상황에 맞는 ref값을 제공한다

## ✍ 궁금한 점
없습니다!