### PR TITLE
[FE] feat#279 터미널에 사용자 이름과 git ref 표시

### DIFF
--- a/packages/frontend/src/apis/quiz.ts
+++ b/packages/frontend/src/apis/quiz.ts
@@ -63,4 +63,5 @@ export type GetSharedAnswerResponse = {
 
 type GetQuizGraphResponse = {
   graph: QuizGitGraph;
+  ref: string;
 };

--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -2,6 +2,8 @@ import {
   type ClipboardEventHandler,
   type KeyboardEventHandler,
   forwardRef,
+  useImperativeHandle,
+  useRef,
 } from "react";
 
 import Prompt from "./Prompt";
@@ -12,8 +14,28 @@ interface CommandInputProps {
   handleInput: KeyboardEventHandler;
 }
 
-const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
+interface ForwardRefType {
+  focus: HTMLOrSVGElement["focus"];
+  scrollIntoView: Element["scrollIntoView"];
+}
+
+const CommandInput = forwardRef<ForwardRefType, CommandInputProps>(
   ({ gitRef, handleInput }, ref) => {
+    const inputRef = useRef<HTMLSpanElement>(null);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus(options) {
+          inputRef.current?.focus(options);
+        },
+        scrollIntoView(arg) {
+          inputRef.current?.scrollIntoView(arg);
+        },
+      }),
+      [],
+    );
+
     const handlePaste: ClipboardEventHandler = (event) => {
       event.preventDefault();
 
@@ -36,8 +58,16 @@ const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
       cursorAnchorNode.remove();
     };
 
+    const handleClick = () => {
+      inputRef.current?.focus();
+    };
+
     return (
-      <div className={styles.commandInputContainer}>
+      <div
+        className={styles.commandInputContainer}
+        onClick={handleClick}
+        aria-hidden
+      >
         <span id="commandLabel" style={{ display: "none" }}>
           Enter git command
         </span>
@@ -51,7 +81,7 @@ const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
           aria-placeholder="git command"
           aria-labelledby="commandLabel"
           tabIndex={0}
-          ref={ref}
+          ref={inputRef}
         />
       </div>
     );

--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -16,10 +16,7 @@ interface CommandInputProps {
   handleInput: KeyboardEventHandler;
 }
 
-interface ForwardRefType {
-  focus: HTMLOrSVGElement["focus"];
-  scrollIntoView: Element["scrollIntoView"];
-}
+type ForwardRefType = Pick<HTMLSpanElement, "focus" | "scrollIntoView">;
 
 const CommandInput = forwardRef<ForwardRefType, CommandInputProps>(
   ({ gitRef, handleInput }, ref) => {

--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -6,6 +6,8 @@ import {
   useRef,
 } from "react";
 
+import { focusRef, scrollIntoViewRef } from "../../utils/refObject";
+
 import Prompt from "./Prompt";
 import * as styles from "./Terminal.css";
 
@@ -27,10 +29,10 @@ const CommandInput = forwardRef<ForwardRefType, CommandInputProps>(
       ref,
       () => ({
         focus(options) {
-          inputRef.current?.focus(options);
+          focusRef(inputRef, options);
         },
         scrollIntoView(arg) {
-          inputRef.current?.scrollIntoView(arg);
+          scrollIntoViewRef(inputRef, arg);
         },
       }),
       [],
@@ -59,7 +61,7 @@ const CommandInput = forwardRef<ForwardRefType, CommandInputProps>(
     };
 
     const handleClick = () => {
-      inputRef.current?.focus();
+      focusRef(inputRef);
     };
 
     return (

--- a/packages/frontend/src/components/terminal/CommandInput.tsx
+++ b/packages/frontend/src/components/terminal/CommandInput.tsx
@@ -4,17 +4,16 @@ import {
   forwardRef,
 } from "react";
 
-import classnames from "../../utils/classnames";
-
 import Prompt from "./Prompt";
 import * as styles from "./Terminal.css";
 
 interface CommandInputProps {
+  gitRef: string;
   handleInput: KeyboardEventHandler;
 }
 
 const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
-  ({ handleInput }, ref) => {
+  ({ gitRef, handleInput }, ref) => {
     const handlePaste: ClipboardEventHandler = (event) => {
       event.preventDefault();
 
@@ -42,9 +41,9 @@ const CommandInput = forwardRef<HTMLSpanElement, CommandInputProps>(
         <span id="commandLabel" style={{ display: "none" }}>
           Enter git command
         </span>
-        <Prompt />
+        <Prompt gitRef={gitRef} />
         <span
-          className={classnames(styles.commandInput, styles.stdin)}
+          className={styles.commandInput}
           contentEditable
           onKeyDown={handleInput}
           onPaste={handlePaste}

--- a/packages/frontend/src/components/terminal/Prompt.css.ts
+++ b/packages/frontend/src/components/terminal/Prompt.css.ts
@@ -1,0 +1,18 @@
+import { style } from "@vanilla-extract/css";
+
+import color from "../../design-system/tokens/color";
+
+export const prompt = style({
+  color: color.$semantic.primary,
+  fontWeight: 700,
+  paddingRight: 7,
+});
+
+export const username = style({
+  paddingRight: 4,
+});
+
+export const gitRef = style({
+  paddingRight: 4,
+  color: color.$semantic.secondary,
+});

--- a/packages/frontend/src/components/terminal/Prompt.tsx
+++ b/packages/frontend/src/components/terminal/Prompt.tsx
@@ -1,5 +1,21 @@
+import classnames from "../../utils/classnames";
+
 import { prompt as promptStyle } from "./Terminal.css";
 
-export default function Prompt() {
-  return <span className={promptStyle}>&gt;&gt;</span>;
+const USER_NAME = "root";
+
+interface PromptProps {
+  gitRef: string;
+}
+
+export default function Prompt({ gitRef }: PromptProps) {
+  return (
+    <span className={promptStyle}>
+      {formatPromptInfo(USER_NAME, gitRef)} &gt;&gt;
+    </span>
+  );
+}
+
+function formatPromptInfo(username: string, gitRef: string) {
+  return classnames(username, gitRef ? `(${gitRef})` : "");
 }

--- a/packages/frontend/src/components/terminal/Prompt.tsx
+++ b/packages/frontend/src/components/terminal/Prompt.tsx
@@ -1,6 +1,4 @@
-import classnames from "../../utils/classnames";
-
-import { prompt as promptStyle } from "./Terminal.css";
+import * as styles from "./Prompt.css";
 
 const USER_NAME = "root";
 
@@ -10,12 +8,10 @@ interface PromptProps {
 
 export default function Prompt({ gitRef }: PromptProps) {
   return (
-    <span className={promptStyle}>
-      {formatPromptInfo(USER_NAME, gitRef)} &gt;&gt;
+    <span className={styles.prompt}>
+      <span className={styles.username}>{USER_NAME}</span>
+      {gitRef && <span className={styles.gitRef}>({gitRef})</span>}
+      &gt;&gt;
     </span>
   );
-}
-
-function formatPromptInfo(username: string, gitRef: string) {
-  return classnames(username, gitRef ? `(${gitRef})` : "");
 }

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -26,12 +26,6 @@ export const terminalContainer = style([
 
 export const commandInputContainer = style([widthFull]);
 
-export const prompt = style({
-  paddingRight: 6,
-  color: color.$semantic.primary,
-  fontWeight: 700,
-});
-
 export const commandInput = style({
   outline: 0,
   wordBreak: "break-all",

--- a/packages/frontend/src/components/terminal/Terminal.css.ts
+++ b/packages/frontend/src/components/terminal/Terminal.css.ts
@@ -4,8 +4,8 @@ import color from "../../design-system/tokens/color";
 import typography from "../../design-system/tokens/typography";
 import {
   border,
-  flexAlignCenter,
   middleLayer,
+  widthFull,
 } from "../../design-system/tokens/utils.css";
 
 export const terminalContainer = style([
@@ -24,31 +24,15 @@ export const terminalContainer = style([
   },
 ]);
 
-export const commandInputContainer = style([
-  flexAlignCenter,
-  {
-    width: "100%",
-    position: "relative",
-  },
-]);
+export const commandInputContainer = style([widthFull]);
 
 export const prompt = style({
-  position: "absolute",
-  top: 1,
-  left: 0,
+  paddingRight: 6,
   color: color.$semantic.primary,
   fontWeight: 700,
 });
 
-export const stdinContainer = style({ position: "relative" });
-
-export const stdin = style({
-  display: "block",
-  textIndent: 22,
-});
-
 export const commandInput = style({
-  flex: 1,
   outline: 0,
   wordBreak: "break-all",
 });

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -8,12 +8,13 @@ import * as styles from "./Terminal.css";
 import TerminalContent from "./TerminalContent";
 
 interface TerminalProps {
+  gitRef: string;
   contentArray: TerminalContentType[];
   onTerminal: (input: string) => void;
 }
 
 const Terminal = forwardRef<HTMLSpanElement, TerminalProps>(
-  ({ contentArray, onTerminal }, ref) => {
+  ({ gitRef, contentArray, onTerminal }, ref) => {
     const handleStandardInput: KeyboardEventHandler = async (event) => {
       const { key, currentTarget } = event;
       if (key !== ENTER_KEY) {
@@ -33,7 +34,11 @@ const Terminal = forwardRef<HTMLSpanElement, TerminalProps>(
     return (
       <div className={styles.terminalContainer}>
         <TerminalContent contentArray={contentArray} />
-        <CommandInput handleInput={handleStandardInput} ref={ref} />
+        <CommandInput
+          gitRef={gitRef}
+          handleInput={handleStandardInput}
+          ref={ref}
+        />
       </div>
     );
   },

--- a/packages/frontend/src/components/terminal/Terminal.tsx
+++ b/packages/frontend/src/components/terminal/Terminal.tsx
@@ -16,8 +16,12 @@ interface TerminalProps {
 const Terminal = forwardRef<HTMLSpanElement, TerminalProps>(
   ({ gitRef, contentArray, onTerminal }, ref) => {
     const handleStandardInput: KeyboardEventHandler = async (event) => {
-      const { key, currentTarget } = event;
-      if (key !== ENTER_KEY) {
+      const {
+        key,
+        currentTarget,
+        nativeEvent: { isComposing },
+      } = event;
+      if (isComposing || key !== ENTER_KEY) {
         return;
       }
 

--- a/packages/frontend/src/components/terminal/TerminalContent.tsx
+++ b/packages/frontend/src/components/terminal/TerminalContent.tsx
@@ -1,7 +1,10 @@
-import type { TerminalContentType } from "../../types/terminalType";
+import type {
+  StandardInputType,
+  StandardOutputType,
+  TerminalContentType,
+} from "../../types/terminalType";
 
 import Prompt from "./Prompt";
-import * as styles from "./Terminal.css";
 
 interface TerminalContentProps {
   contentArray: TerminalContentType[];
@@ -14,25 +17,19 @@ export default function TerminalContent({
   return <div>{content}</div>;
 }
 
-const contentMap = {
-  stdin: StandardInputContent,
-  stdout: StandardOutputContent,
-};
-
-interface ContentProps {
-  content: string;
-}
-
-function StandardInputContent({ content }: ContentProps) {
+function StandardInputContent({
+  content,
+  gitRef,
+}: Omit<StandardInputType, "type">) {
   return (
-    <div className={styles.stdinContainer}>
-      <Prompt />
-      <span className={styles.stdin}>{content}</span>
+    <div>
+      <Prompt gitRef={gitRef} />
+      <span>{content}</span>
     </div>
   );
 }
 
-function StandardOutputContent({ content }: ContentProps) {
+function StandardOutputContent({ content }: Omit<StandardOutputType, "type">) {
   return (
     <div>
       <span>{content}</span>
@@ -41,9 +38,21 @@ function StandardOutputContent({ content }: ContentProps) {
 }
 
 function toTerminalContentComponent(
-  { type, content }: TerminalContentType,
+  propsWithType: TerminalContentType,
   index: number,
 ) {
-  const Content = contentMap[type];
-  return <Content key={[type, index].join("-")} content={content} />;
+  const key = `${propsWithType.type} ${index}`;
+  switch (propsWithType.type) {
+    case "stdin": {
+      const { type, ...props } = propsWithType;
+      return <StandardInputContent key={key} {...props} />;
+    }
+    case "stdout": {
+      const { type, ...props } = propsWithType;
+      return <StandardOutputContent key={key} {...props} />;
+    }
+    default: {
+      return null;
+    }
+  }
 }

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -184,6 +184,7 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
             <Editor initialFile={editorFile} onSubmit={handleTerminal} />
           ) : (
             <Terminal
+              gitRef={gitRef}
               contentArray={contentArray}
               onTerminal={handleTerminal}
               ref={terminalInputRef}

--- a/packages/frontend/src/pages/quizzes/[id].page.tsx
+++ b/packages/frontend/src/pages/quizzes/[id].page.tsx
@@ -37,6 +37,7 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
   } = router;
 
   const [gitGraphData, setGitGraphData] = useState<QuizGitGraphCommit[]>([]);
+  const [gitRef, setGitRef] = useState("");
   const userQuizStatusDispatcher = useUserQuizStatusDispatch();
 
   const solvedModal = useSolvedModal(isString(id) ? +id : -1);
@@ -47,8 +48,9 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
 
   const fetchGitGraphDataRef = useRef(async (curId: number) => {
     try {
-      const { graph: nextGraph } = await quizAPI.getGraph(curId);
-      setGitGraphData(nextGraph);
+      const { graph, ref } = await quizAPI.getGraph(curId);
+      setGitGraphData(graph);
+      setGitRef(ref);
     } catch (error) {
       handleResponseError(error);
     }
@@ -60,7 +62,12 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
     }
 
     try {
-      const { result, message, graph } = await quizAPI.postCommand({
+      const {
+        result,
+        message,
+        graph,
+        ref: nextGitRef,
+      } = await quizAPI.postCommand({
         id: +id,
         mode: terminalMode,
         message: input,
@@ -72,7 +79,9 @@ export default function QuizPage({ quiz }: { quiz: Quiz }) {
         type: terminalActionTypeMap[terminalMode][result],
         input,
         message,
+        gitRef,
       });
+      setGitRef(nextGitRef);
     } catch (error) {
       handleResponseError(error, terminalMode);
     }

--- a/packages/frontend/src/reducers/terminalReducer/index.ts
+++ b/packages/frontend/src/reducers/terminalReducer/index.ts
@@ -1,0 +1,6 @@
+export {
+  terminalReducer,
+  initialTerminalState,
+  terminalActionTypeMap,
+} from "./terminalReducer";
+export { TerminalActionTypes } from "./type";

--- a/packages/frontend/src/reducers/terminalReducer/terminalReducer.ts
+++ b/packages/frontend/src/reducers/terminalReducer/terminalReducer.ts
@@ -17,7 +17,7 @@ export function terminalReducer(
         ...state,
         contentArray: [
           ...state.contentArray,
-          toStandardInput(action.input),
+          toStandardInput(action.input, action.gitRef),
           toStandardOutput(action.message),
         ],
       };
@@ -25,7 +25,10 @@ export function terminalReducer(
     case TerminalActionTypes.commandToEditor:
       return {
         terminalMode: "editor",
-        contentArray: [...state.contentArray, toStandardInput(action.input)],
+        contentArray: [
+          ...state.contentArray,
+          toStandardInput(action.input, action.gitRef),
+        ],
         editorFile: action.message,
       };
 

--- a/packages/frontend/src/reducers/terminalReducer/terminalReducer.ts
+++ b/packages/frontend/src/reducers/terminalReducer/terminalReducer.ts
@@ -1,4 +1,5 @@
-import { TerminalContentType } from "../types/terminalType";
+import { TerminalAction, TerminalActionTypes, TerminalState } from "./type";
+import { toStandardInput, toStandardOutput } from "./util";
 
 export const initialTerminalState: TerminalState = {
   terminalMode: "command",
@@ -49,32 +50,6 @@ export function terminalReducer(
   }
 }
 
-function toStandardInput(content: string) {
-  return toContentArrayItem("stdin", content);
-}
-
-function toStandardOutput(content: string) {
-  return toContentArrayItem("stdout", content);
-}
-
-function toContentArrayItem(type: "stdin" | "stdout", content: string) {
-  return { type, content };
-}
-
-type TerminalState = {
-  terminalMode: "command" | "editor";
-  editorFile: string;
-  contentArray: TerminalContentType[];
-};
-
-export enum TerminalActionTypes {
-  commandToCommand = "commandToCommand",
-  commandToEditor = "commandToEditor",
-  editorToCommand = "editorToCommand",
-  editorToEditor = "editorToEditor",
-  reset = "reset",
-}
-
 export const terminalActionTypeMap = {
   command: {
     success: TerminalActionTypes.commandToCommand,
@@ -86,23 +61,4 @@ export const terminalActionTypeMap = {
     fail: TerminalActionTypes.editorToCommand,
     editor: TerminalActionTypes.editorToEditor,
   },
-};
-
-type TerminalAction =
-  | CommandToCommand
-  | CommandToEditor
-  | EditorToCommand
-  | EditorToEditor
-  | ClearTerminal;
-
-type CommandToCommand = RequestToResponse<TerminalActionTypes.commandToCommand>;
-type CommandToEditor = RequestToResponse<TerminalActionTypes.commandToEditor>;
-type EditorToCommand = RequestToResponse<TerminalActionTypes.editorToCommand>;
-type EditorToEditor = RequestToResponse<TerminalActionTypes.editorToEditor>;
-type ClearTerminal = { type: TerminalActionTypes.reset };
-
-type RequestToResponse<Type> = {
-  type: Type;
-  input: string;
-  message: string;
 };

--- a/packages/frontend/src/reducers/terminalReducer/type.ts
+++ b/packages/frontend/src/reducers/terminalReducer/type.ts
@@ -1,0 +1,34 @@
+import { TerminalContentType } from "../../types/terminalType";
+
+export type TerminalState = {
+  terminalMode: "command" | "editor";
+  editorFile: string;
+  contentArray: TerminalContentType[];
+};
+
+export enum TerminalActionTypes {
+  commandToCommand = "commandToCommand",
+  commandToEditor = "commandToEditor",
+  editorToCommand = "editorToCommand",
+  editorToEditor = "editorToEditor",
+  reset = "reset",
+}
+
+export type TerminalAction =
+  | CommandToCommand
+  | CommandToEditor
+  | EditorToCommand
+  | EditorToEditor
+  | ClearTerminal;
+
+type CommandToCommand = RequestToResponse<TerminalActionTypes.commandToCommand>;
+type CommandToEditor = RequestToResponse<TerminalActionTypes.commandToEditor>;
+type EditorToCommand = RequestToResponse<TerminalActionTypes.editorToCommand>;
+type EditorToEditor = RequestToResponse<TerminalActionTypes.editorToEditor>;
+type ClearTerminal = { type: TerminalActionTypes.reset };
+
+type RequestToResponse<Type> = {
+  type: Type;
+  input: string;
+  message: string;
+};

--- a/packages/frontend/src/reducers/terminalReducer/type.ts
+++ b/packages/frontend/src/reducers/terminalReducer/type.ts
@@ -31,4 +31,5 @@ type RequestToResponse<Type> = {
   type: Type;
   input: string;
   message: string;
+  gitRef: string;
 };

--- a/packages/frontend/src/reducers/terminalReducer/util.ts
+++ b/packages/frontend/src/reducers/terminalReducer/util.ts
@@ -1,0 +1,11 @@
+export function toStandardInput(content: string) {
+  return toContentArrayItem("stdin", content);
+}
+
+export function toStandardOutput(content: string) {
+  return toContentArrayItem("stdout", content);
+}
+
+export function toContentArrayItem(type: "stdin" | "stdout", content: string) {
+  return { type, content };
+}

--- a/packages/frontend/src/reducers/terminalReducer/util.ts
+++ b/packages/frontend/src/reducers/terminalReducer/util.ts
@@ -1,11 +1,15 @@
-export function toStandardInput(content: string) {
-  return toContentArrayItem("stdin", content);
+import {
+  StandardInputType,
+  StandardOutputType,
+} from "../../types/terminalType";
+
+export function toStandardInput(
+  content: string,
+  gitRef: string = "",
+): StandardInputType {
+  return { type: "stdin", content, gitRef };
 }
 
-export function toStandardOutput(content: string) {
-  return toContentArrayItem("stdout", content);
-}
-
-export function toContentArrayItem(type: "stdin" | "stdout", content: string) {
-  return { type, content };
+export function toStandardOutput(content: string): StandardOutputType {
+  return { type: "stdout", content };
 }

--- a/packages/frontend/src/types/quiz.ts
+++ b/packages/frontend/src/types/quiz.ts
@@ -6,6 +6,7 @@ export type Command = {
   message: string;
   result: CommandSuccess | CommandFail | CommandEditor;
   graph?: QuizGitGraph;
+  ref: string;
 };
 
 export type Quiz = {

--- a/packages/frontend/src/types/terminalType.ts
+++ b/packages/frontend/src/types/terminalType.ts
@@ -1,6 +1,9 @@
 export type TerminalContentType = StandardInputType | StandardOutputType;
 
-export type StandardInputType = WithContentType<"stdin">;
-export type StandardOutputType = WithContentType<"stdout">;
+export type StandardInputType = {
+  type: "stdin";
+  content: string;
+  gitRef: string;
+};
 
-type WithContentType<T> = { type: T; content: string };
+export type StandardOutputType = { type: "stdout"; content: string };

--- a/packages/frontend/src/utils/refObject.ts
+++ b/packages/frontend/src/utils/refObject.ts
@@ -1,9 +1,15 @@
 import { RefObject } from "react";
 
-export function focusRef<T extends HTMLOrSVGElement>(ref: RefObject<T>) {
-  ref.current?.focus();
+export function focusRef<T extends HTMLOrSVGElement>(
+  ref: RefObject<T>,
+  options?: FocusOptions,
+) {
+  ref.current?.focus(options);
 }
 
-export function scrollIntoViewRef<T extends Element>(ref: RefObject<T>) {
-  ref.current?.scrollIntoView();
+export function scrollIntoViewRef<T extends Element>(
+  ref: RefObject<T>,
+  arg?: boolean | ScrollIntoViewOptions,
+) {
+  ref.current?.scrollIntoView(arg);
 }


### PR DESCRIPTION
close #279 

## ✅ 작업 내용
- 터미널에 사용자 이름과 git ref 표시
- 명령어 입력, 그래프 조회 API 응답 타입에 ref 필드 추가
- terminalReducer.ts 코드가 복잡해져 유틸 함수, 타입 분리
- 터미널에 명령어 입력할 때 한글을 작성하고 Enter를 누르면 콜백 함수가 2번 호출되는 버그 수정
  ![terminal 한글 콜백 2번](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/8b0e7102-b387-4179-b7fa-61518cbc41ba)
- `CommandInput` 클릭 가능한 영역 확장
  - 스타일링 변경으로 터미널에 포커싱하기 힘들어졌습니다. gitRef를 추가하면서 `Prompt` 너비가 가변적이라, `Prompt`와 출력값 모두 `inline` 으로 변경했습니다. 그런데 `inline`이다 보니 `width`를 적용할 수 없어 아래처럼 명령어를 입력할 수 있는 `CommandInput` 너비가 0이 됩니다. 이때 사용자가 터미널에 포커싱하기 조금 힘들어졌습니다. 그래서 `CommandInput` 부모 영역을 클릭하면 `CommandInput`에 포커스되도록 변경했습니다.

  |AS-IS|TO-BE|
  |-|-|
  |<img width="945" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/049027b2-a1dc-4f5d-b5f8-171ba6d1d868">|<img width="943" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/a65cf5ad-43d7-4082-b603-0223a496e9ab">|

  ![command input focus issue](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/3b2b6ecc-2ba9-41e4-894c-1a8cac8a0daa)

## 📸 스크린샷
![terminal gitref](https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/bd57d894-54bd-4d7f-af10-ec01371a102b)


## 📌 이슈 사항
- 없습니다!

## 🟢 완료 조건
- 터미널에 사용자 이름이 보인다.
- 현재 Git 저장소가 있다면, 터미널에 사용자 이름과 함께 git ref가 보인다.

## ✍ 궁금한 점
- git ref 까지 동일한 색상으로 스타일링하면 사용자 이름과 git ref 구분이 뚜렷하지 않아 임의로 primary, secondary 적용했습니다. 변경하고 싶으면 알려주세요! (제 테마랑 비슷하게 만들어버렸네요...[여기](https://github.com/ohmyzsh/ohmyzsh/wiki/Themes) 보면 테마 다양해요!)
 
  |||
  |-|-|
  |<img width="284" alt="스크린샷 2023-12-13 오후 3 53 31" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/cc43cecf-3715-4861-a405-fd38e5c9e93b">|<img width="179" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/96400112/39ac5d6d-d6a6-4ade-b6cf-8cf70f41fedf">|

