### PR TITLE
[FE] feat#254 그래프 hover시에 툴팁으로 커밋 정보 안내, UX 개선

### DIFF
--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -24,7 +24,6 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
   const svg = d3.select(svgRef.current);
 
   if (!parsedData.length) {
-    svg.select("#text").selectAll("*").remove();
     svg.select("#link").selectAll("*").remove();
     svg.select("#node").selectAll("*").remove();
     return;
@@ -44,24 +43,6 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
   // Apply the tree layout to the hierarchical data
   const treeData = treeLayout(rootNode);
   fillColor(treeData);
-
-  // Add text next to each node
-  svg
-    .select("#text")
-    .selectAll("text")
-    .data(treeData.descendants())
-    .join(
-      (enter) => enter.append("text").style("opacity", 0),
-      (update) => update,
-      (exit) =>
-        exit.transition().duration(DURATION).style("opacity", 0).remove(),
-    )
-    .text((d) => d.data.message)
-    .attr("x", (d) => d.x + 20)
-    .attr("y", (d) => d.y + 5)
-    .transition()
-    .duration(DURATION)
-    .style("opacity", 1);
 
   additionalLinks.forEach(({ id, parentId }) => {
     const sourceNode = treeData.descendants().filter((d) => d.id === id)[0];
@@ -138,7 +119,6 @@ export function Graph({ data, className = "" }: GraphProps) {
         <g ref={gRef} transform="translate(100,70)">
           <g id="link" />
           <g id="node" />
-          <g id="text" />
         </g>
       </svg>
     </div>

--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -102,6 +102,7 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
     .transition()
     .duration(DURATION)
     .style("opacity", 1)
+    .style("cursor", "pointer")
     .attr(
       "fill",
       (d: d3.HierarchyPointNode<InitialDataProps>) => d.data?.color ?? "",

--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -106,6 +106,17 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
       "fill",
       (d: d3.HierarchyPointNode<InitialDataProps>) => d.data?.color ?? "",
     );
+
+  svg.select("#node").on("mouseout", (event) => {
+    const nodeNotHovered = !(
+      event.relatedTarget.nodeName === "rect" ||
+      event.relatedTarget.nodeName === "tspan"
+    );
+
+    if (nodeNotHovered) {
+      svg.select("#tooltip").remove();
+    }
+  });
 }
 
 interface GraphProps {

--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -6,6 +6,7 @@ import { QuizGitGraphCommit } from "../../types/quiz";
 
 import fillColor from "./fillColor";
 import { InitialDataProps, parsingMultipleParents } from "./parsing";
+import renderTooltip from "./renderTooltip";
 
 const { grey500 } = color.$scale;
 
@@ -87,6 +88,12 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
       (exit) =>
         exit.transition().duration(DURATION).style("opacity", 0).remove(),
     )
+    .on("mouseover", (event, d) => {
+      const existingTooltip = svg.select("#tooltip");
+      if (existingTooltip.empty()) {
+        renderTooltip(svg, d);
+      }
+    })
     .attr("cx", (d) => d.x)
     .attr("cy", (d) => d.y)
     .attr("r", 13)

--- a/packages/frontend/src/components/graph/Graph.tsx
+++ b/packages/frontend/src/components/graph/Graph.tsx
@@ -109,12 +109,10 @@ function renderD3(svgRef: RefObject<SVGGElement>, data: InitialDataProps[]) {
     );
 
   svg.select("#node").on("mouseout", (event) => {
-    const nodeNotHovered = !(
+    const hoverTooltip =
       event.relatedTarget.nodeName === "rect" ||
-      event.relatedTarget.nodeName === "tspan"
-    );
-
-    if (nodeNotHovered) {
+      event.relatedTarget.nodeName === "tspan";
+    if (!hoverTooltip) {
       svg.select("#tooltip").remove();
     }
   });

--- a/packages/frontend/src/components/graph/renderTooltip.ts
+++ b/packages/frontend/src/components/graph/renderTooltip.ts
@@ -79,5 +79,36 @@ export default function renderTooltip(
     .append("tspan")
     .attr("fill", color.$scale.grey700)
     .text((tooltipData: TooltipProps) => tooltipData.value)
-    .attr("id", (tooltipData: TooltipProps) => tooltipData.id);
+    .attr("id", (tooltipData: TooltipProps) => tooltipData.id)
+    .each(() => {
+      const currentValueNode: d3.Selection<
+        SVGTSpanElement | null,
+        unknown,
+        HTMLElement,
+        undefined
+      > = d3.select("#value");
+
+      if (!currentValueNode.empty() && currentValueNode.node()) {
+        const tspanMaxWidth = 110;
+        const originalText = currentValueNode.text();
+
+        let start = 0;
+        let end = tspanMaxWidth;
+        let mid;
+        while (start < end) {
+          mid = Math.floor((start + end) / 2);
+          const truncatedText = `${originalText.slice(0, mid)}...`;
+          currentValueNode.text(truncatedText); // Set text here for width calculation
+          const textWidth =
+            currentValueNode?.node()?.getComputedTextLength() || 0;
+          if (textWidth > tspanMaxWidth) {
+            end = mid;
+          } else {
+            start = mid + 1;
+          }
+        }
+        const truncatedText = `${originalText.slice(0, start - 1)}...`;
+        currentValueNode.text(truncatedText);
+      }
+    });
 }

--- a/packages/frontend/src/components/graph/renderTooltip.ts
+++ b/packages/frontend/src/components/graph/renderTooltip.ts
@@ -58,10 +58,9 @@ export default function renderTooltip(
     .append("rect")
     .attr("width", 30)
     .attr("height", 30)
-    // 요기나
-    .attr("fill", "transparent")
     // 요기 바꿔보심 돼여
-    .attr("stroke", color.$scale.grey300)
+    .attr("fill", "transparent")
+    .style("cursor", "pointer")
     .attr("transform", transparentRectPosition);
 
   tooltip

--- a/packages/frontend/src/components/graph/renderTooltip.ts
+++ b/packages/frontend/src/components/graph/renderTooltip.ts
@@ -21,7 +21,7 @@ export default function renderTooltip(
     position: `translate(${d.x - 110},${d.y - 60})`,
   };
 
-  const transparentRectPosition = "translate(85, 40)";
+  const transparentRectPosition = "translate(95, 40)";
 
   const tooltipDataFormat = [
     {
@@ -61,7 +61,7 @@ export default function renderTooltip(
     // 요기나
     .attr("fill", "transparent")
     // 요기 바꿔보심 돼여
-    // .attr("stroke", color.$scale.grey300)
+    .attr("stroke", color.$scale.grey300)
     .attr("transform", transparentRectPosition);
 
   tooltip
@@ -91,6 +91,9 @@ export default function renderTooltip(
       if (!currentValueNode.empty() && currentValueNode.node()) {
         const tspanMaxWidth = 110;
         const originalText = currentValueNode.text();
+        if (currentValueNode.node()!.getComputedTextLength() < tspanMaxWidth) {
+          return;
+        }
 
         let start = 0;
         let end = tspanMaxWidth;

--- a/packages/frontend/src/components/graph/renderTooltip.ts
+++ b/packages/frontend/src/components/graph/renderTooltip.ts
@@ -1,0 +1,83 @@
+import * as d3 from "d3";
+
+import color from "../../design-system/tokens/color";
+
+import { InitialDataProps } from "./parsing";
+
+interface TooltipProps {
+  text: string;
+  value: string;
+  id: string;
+}
+
+export default function renderTooltip(
+  svg,
+  d: d3.HierarchyPointNode<InitialDataProps>,
+) {
+  const tooltipStyle = {
+    width: 220,
+    height: 40,
+    borderRadius: 5,
+    position: `translate(${d.x - 110},${d.y - 60})`,
+  };
+
+  const transparentRectPosition = "translate(85, 40)";
+
+  const tooltipDataFormat = [
+    {
+      text: "Commit Hash: ",
+      value: d.data.id.slice(0, 7),
+      id: "text",
+    },
+    {
+      text: "Commit Message: ",
+      value: d.data.message,
+      id: "value",
+    },
+  ];
+
+  // hover 시 보이는 툴팁
+  const tooltip = svg
+    .select("#node")
+    .append("g")
+    .attr("id", "tooltip")
+    .attr("tabindex", 0)
+    .attr("transform", tooltipStyle.position);
+
+  tooltip
+    .append("rect")
+    .attr("width", tooltipStyle.width)
+    .attr("height", tooltipStyle.height)
+    .attr("rx", tooltipStyle.borderRadius)
+    .attr("ry", tooltipStyle.borderRadius)
+    .attr("fill", color.$semantic.bgDefault)
+    .attr("stroke", color.$scale.grey300);
+
+  // 투명한 네모를 위에 위치시키기
+  tooltip
+    .append("rect")
+    .attr("width", 30)
+    .attr("height", 30)
+    // 요기나
+    .attr("fill", "transparent")
+    // 요기 바꿔보심 돼여
+    // .attr("stroke", color.$scale.grey300)
+    .attr("transform", transparentRectPosition);
+
+  tooltip
+    .append("text")
+    .attr("x", 0)
+    .attr("y", 16.5)
+    .selectAll("tspan")
+    .data(tooltipDataFormat)
+    .enter()
+    .append("tspan")
+    .attr("x", 6)
+    .attr("dy", (_: TooltipProps, index: number) => index * 15) // Adjust the line height as needed
+    .text((tooltipData: TooltipProps) => tooltipData.text)
+    .attr("fill", color.$scale.grey600)
+    .append("tspan")
+    .attr("fill", color.$scale.grey700)
+    .text((tooltipData: TooltipProps) => tooltipData.value)
+    .attr("id", (tooltipData: TooltipProps) => tooltipData.id);
+}

--- a/packages/frontend/src/components/graph/renderTooltip.ts
+++ b/packages/frontend/src/components/graph/renderTooltip.ts
@@ -11,7 +11,7 @@ interface TooltipProps {
 }
 
 export default function renderTooltip(
-  svg,
+  svg: d3.Selection<SVGGElement | null, unknown, null, undefined>,
   d: d3.HierarchyPointNode<InitialDataProps>,
 ) {
   const tooltipStyle = {

--- a/packages/frontend/src/pages/_app.page.tsx
+++ b/packages/frontend/src/pages/_app.page.tsx
@@ -44,7 +44,6 @@ export default function App({ Component, pageProps }: AppProps) {
         <UserQuizStatusProvider initialUserQuizStatus={userQuizStatus}>
           <ThemeWrapper>
             <Layout>
-              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
               <Component {...pageProps} />
             </Layout>
           </ThemeWrapper>

--- a/packages/frontend/src/pages/_document.page.tsx
+++ b/packages/frontend/src/pages/_document.page.tsx
@@ -2,7 +2,7 @@ import { Head, Html, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html data-theme="light" lang="en">
+    <Html data-theme="light" lang="ko">
       <Head>
         <link
           rel="apple-touch-icon"


### PR DESCRIPTION
close #254 

## ✅ 작업 내용
- 기존 텍스트 노드 삭제 후 툴팁 추가
   - 그래프 circle 노드에 hover시에 툴팁으로 커밋 해시, 커밋 메시지 안내
  - tspan 요소의 텍스트 너비(tspan이라 길이 아니고 너비에요! 한글이랑 영어랑 길이가 달라요)가 정해진 길이를 넘어가면 자르고 말줄임을 추가하도록 구현
   - circle 노드에 커서 포인터 설정

- 툴팁, circle에서 툴팁으로 가는 경로에 hover하면 꺼지지 않도록, 그리고 요소에 mouseout되면 꺼지도록 구현
이게 가장 큰 어려움이였는데, 툴팁으로 가는 경로에 투명한 rect svg 요소를 넣어서 해결할 수 있었습니다! 
(테스트용으로 border 처리해놓은 rect입니다)
<img width="266" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/bb695b66-4262-4b8f-bf30-6cd97a5628cb">

그리고 노드 자체에 mouseout 이벤트를 넣어 노드가 호버된게 아니라면 툴팁을 지우도록 구현하였습니다!
```typescript
  svg.select("#node").on("mouseout", (event) => {
    const nodeNotHovered = !(
      event.relatedTarget.nodeName === "rect" ||
      event.relatedTarget.nodeName === "tspan"
    );

    if (nodeNotHovered) {
      svg.select("#tooltip").remove();
    }
  });
```
## 📸 스크린샷(FE만)

|기존|1차 구현|2차 구현 (UX 개선)|
|-|-|-|
|<img width="700" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/9e386617-cd7d-4753-a6c6-8848d7b43c17">|![Dec-13-2023 16-22-44](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/e30f7ea3-2dcd-4b29-a649-e746fa11c096)|![Dec-13-2023 18-31-07](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/8c0c5085-af7b-48ee-b854-9da038deb2a7)|

## 📌 이슈 사항
- 툴팁이 한번 렌더링되고 나서 update 함수로 다시 렌더링 되지 않고 내용만 바뀌도록 구현하고 싶은데 당장 코앞이 데모라 구현하지 못했습니다🥲

## 🟢 완료 조건
- 텍스트로 보여주는 커밋 메시지를 지우고 툴팁으로 정보를 보여준다

## ✍ 궁금한 점
- 노드에 호버되었냐는 불리언 변수인데 더 좋은거 없을까요..ㅠㅠ
```typescript
 const nodeNotHovered = !(
      event.relatedTarget.nodeName === "rect" ||
      event.relatedTarget.nodeName === "tspan"
    );
```