### PR TITLE
[BE} feat#295 큰따옴표 문제 해결 및 graph 관련 500 에러 버그 픽스

### DIFF
--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -44,7 +44,7 @@ export class ContainersService {
   }
 
   private getGitCommand(container: string, command: string): string {
-    return `${DOCKER_QUIZZER_COMMAND} ${container} sh -c "git config --global core.editor /editor/output.sh; ${command}"`;
+    return `${DOCKER_QUIZZER_COMMAND} ${container} ${command}`;
   }
   async runGitCommand(
     container: string,
@@ -100,7 +100,7 @@ export class ContainersService {
   private buildEditorCommand(message: string, command: string) {
     const escapedMessage = shellEscape([message]);
 
-    return `git config --global core.editor /editor/input.sh; echo ${escapedMessage} | ${command}`;
+    return `git config --global core.editor /editor/input.sh; echo ${escapedMessage} | ${command}; git config --global core.editor /editor/output.sh`;
   }
 
   async runEditorCommand(

--- a/packages/backend/src/session/session.service.ts
+++ b/packages/backend/src/session/session.service.ts
@@ -240,7 +240,7 @@ export class SessionService {
   async isReseted(sessionId: string, problemId: number): Promise<boolean> {
     const session = await this.getSessionById(sessionId);
     if (!session.problems.get(problemId)) {
-      throw new Error('problem not found');
+      return true;
     }
     return session.problems.get(problemId).logs.length === 0;
   }


### PR DESCRIPTION
close #295

## ✅ 작업 내용

- git command 실행 시에는 sh -c 사용하지 않아서 큰따옴표 이용 가능
- isReseted 실행할 때 문제를 못 찾으면 한 번도 안 푼 문제인 거라서 true 리턴

## 📌 이슈 사항

- 아까 코드리뷰 제대로 못 한 것 같아서 너무 아쉽네요. 마음만 급했나 봐요.

## 🟢 완료 조건

- 큰따옴표 입력은 테스트 코드와 postman으로 확인
- 500에러 버그 픽스
- 모든 테스트 케이스 통과

## ✍ 궁금한 점

- 없습니다!