### PR TITLE
[BE] feat#306 모니터링 스택 설치

### DIFF
--- a/packages/backend/monitoring/docker-compose.monitoring.yml
+++ b/packages/backend/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,51 @@
+version: '3'
+
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus-data:/prometheus/data
+      - ./prometheus.yml:/prometheus/prometheus.yml:ro
+    ports:
+      - 9090:9090
+    command:
+      - "--web.enable-lifecycle"
+    restart: always
+    networks:
+      - promnet
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    user: root
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    volumes:
+      - ./grafana-volume:/var/lib/grafana
+    restart: always
+    networks:
+      - promnet
+    ports:
+      - 5000:3000
+    user: root
+
+  cadvisor:
+    image: google/cadvisor:latest
+    container_name: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    ports:
+      - 18080:8080
+    restart: always
+    networks:
+      - promnet
+    user: root
+
+networks:
+  promnet:
+    driver: bridge

--- a/packages/backend/src/containers/containers.service.ts
+++ b/packages/backend/src/containers/containers.service.ts
@@ -37,7 +37,9 @@ export class ContainersService {
 
   async initializeContainers() {
     const { stdoutData: existingContainers } =
-      await this.commandService.executeCommand('docker ps -aq');
+      await this.commandService.executeCommand(
+        'docker ps -aq --filter "label=git"',
+      );
     const existingContainersSet = new Set(
       existingContainers.split('\n').filter((id) => id),
     );
@@ -172,8 +174,7 @@ export class ContainersService {
 
     const containerId = uuidv4();
 
-    const createContainerCommand = `docker run -itd --network none -v ~/editor:/editor \
---name ${containerId} mergemasters/alpine-git:0.2 /bin/sh`;
+    const createContainerCommand = `docker run -itd --network none -v ~/editor:/editor --name ${containerId} --label git=true mergemasters/alpine-git:0.2 /bin/sh`;
     const copyFilesCommand = `docker cp ~/quizzes/${quizId}/. ${containerId}:/home/${user}/quiz/`;
     const copyOriginCommand = `[ -d ~/origins/${quizId} ] && docker cp ~/origins/${quizId}/. ${containerId}:/origin/`;
     const copyUpstreamCommand = `[ -d ~/upstreams/${quizId} ] && docker cp ~/upstreams/${quizId}/. ${containerId}:/upstream/`;


### PR DESCRIPTION
close #306 

## ✅ 작업 내용

- git-challenge 서버, container 서버 각각에 cAdvisor(도커 모니터링 익스포터), node exporter 설치
- git-challenge 서버에 docker compose 이용해서 prometheus, grafana, cAdvisor 배포
- ACG설정
  - git-challenge 서버로만 3000, 8080, 8081이 적용되도록 변경
  - 테스트 용도로 박용준 집에서만 9090포트 접속 가능(prometheus)
  - 5000 포트를 통해 [grafana](http://49.50.167.71:5000) 접속 가능
- container 서버에 도커 모니터링을 위해서 cAdvisor 가 도커 컨테이너 형태로 배포돠어야 함
  => 기존 컨테이너 전체 삭제 로직 하면 모니터링도 안 됨
  => git 환경 제공하는 컨테이너에 `git`이라는 라벨을, cAdvisor에는 `monitoring`이라는 라벨을 부착해서 삭제 시 필터링
- docker compose yml은 공개 가능해서 여기다 올리지만, prometheus.yml파일은 비밀이 가득하므로 리포지토리에는 안 올렸어요. 직접 들어가서 보셔도 됩니다~
- 그리고 폴더 구조도 조금 고민이었는데, 일단 제가 작업하는 거니까 backend 안에 놓아 봤어요~
- 그라파나 대시보드
  - node_exporter, cAdvisor각각에 대해 가장 유명한 대시보드 가져다 둔 상태이고, 차후에 커스텀 대시보드 제작 예정~

## 📌 이슈 사항

- 없습니다. 오늘은 설치 정도만 해 두고, 커스텀 대시보드나 알람 설정 추가해 볼게요~
- 아직 시간 투자가 안 돼서 문서화가 없는데, 이것도 곧 추가하겠습니다~

## 🟢 완료 조건

- 49.50.167.71:5000에서 서버 상태와 컨테이너 상태 모니터링 가능

## ✍ 궁금한 점

- 없습니다.