### PR TITLE
[BE] feat#309 시스템 장애 알람 설정

### DIFF
--- a/packages/backend/monitoring/alert.rules.yml
+++ b/packages/backend/monitoring/alert.rules.yml
@@ -1,0 +1,95 @@
+groups:
+- name: system_alerts
+  rules:
+  # CPU Alerts
+  - alert: HighCpuLoad
+    expr: (100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 90
+    for: 30s
+    labels:
+      severity: critical
+    annotations:
+      summary: CPU 사용량 부하 감지 (30초 간 90%+)
+
+  - alert: HighCpuLoad
+    expr: (100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: CPU 사용량 부하 감지 (30분 간 80%+)
+
+  # Memory Alerts
+  - alert: HighMemoryLoad
+    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 90
+    for: 30s
+    labels:
+      severity: critical
+    annotations:
+      summary: 메모리 사용량 부하 감지 (30초 간 90%+)
+
+  - alert: HighMemoryLoad
+    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 80
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: 메모리 사용량 부하 감지 (30분 간 80%+)
+
+  # Disk Alerts
+  #- alert: HighDiskUsage
+  #  expr: (node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100 > 90
+  #  for: 1m
+  #  labels:
+  #    severity: warning
+  #  annotations:
+  #    summary: 디스크 사용량 90% 돌파 감지
+
+  - alert: HighDiskUsage
+    expr: (node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100 > 95
+    for: 30s
+    labels:
+      severity: critical
+    annotations:
+      summary: 디스크 사용량 95% 돌파 감지
+
+  # Container Count Alerts
+  - alert: HighContainerCount
+    expr: count by (job)(container_last_seen{image!=""}) > 350
+    for: 30s
+    labels:
+      severity: warning
+    annotations:
+      summary: 컨테이너 수 350개 돌파 감지
+
+  - alert: HighContainerCount
+    expr: count by (job)(container_last_seen{image!=""}) > 400
+    for: 30s
+    labels:
+      severity: critical
+    annotations:
+      summary: 컨테이너 수 400개 돌파 감지
+
+  # HttpAlerts
+  - alert: FrontendDown
+    expr: probe_success{service="frontend"} == 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: 프론트엔드 서버 장애 감지
+
+  - alert: GitChallengeDown
+    expr: probe_success{service="git_challenge"} == 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: git-challenge.com 도메인 장애 감지
+
+  - alert: BackendDown
+    expr: (probe_success{service="backend_8080"} == 0 and probe_success{service="backend_8081"} == 0)
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: 백엔드 서버 장애 감지

--- a/packages/backend/monitoring/alertmanager.yml
+++ b/packages/backend/monitoring/alertmanager.yml
@@ -1,0 +1,33 @@
+global:
+  resolve_timeout: 3h
+
+route:
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 3h
+  repeat_interval: 3h
+  receiver: 'slack-notifications'
+
+receivers:
+- name: 'slack-notifications'
+  slack_configs:
+  - api_url: 'https://hooks.slack.com/services/(your secret)'
+    channel: '#monitoring'
+    text: |
+      {{ .Alerts | len }} 개의 알람 발생 중...
+
+      {{ range .Alerts }}
+      탐지 인스턴스: {{ .Labels.job }}
+      알람명: {{ .Labels.alertname }}
+      위험도: {{ .Labels.severity }}
+      내용: {{ .Annotations.summary }}
+
+      {{ end }}
+      대시보드 링크: (your dashboard link)
+
+inhibit_rules:
+- source_match:
+    severity: 'critical'
+  target_match:
+    severity: 'warning'
+  equal: ['alertname']

--- a/packages/backend/monitoring/blackbox.yml
+++ b/packages/backend/monitoring/blackbox.yml
@@ -1,0 +1,6 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET

--- a/packages/backend/monitoring/docker-compose.monitoring.yml
+++ b/packages/backend/monitoring/docker-compose.monitoring.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./prometheus-data:/prometheus/data
       - ./prometheus.yml:/prometheus/prometheus.yml:ro
+      - ./alert.rules.yml:/prometheus/alert.rules.yml:ro
     ports:
       - 9090:9090
     command:
@@ -30,6 +31,19 @@ services:
       - 5000:3000
     user: root
 
+  alertmanager:
+    image: prom/alertmanager
+    container_name: alertmanager
+    volumes:
+      - ./alertmanager-data:/alertmanager
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    ports:
+      - 9093:9093
+    restart: always
+    networks:
+      - promnet
+    user: root
+
   cadvisor:
     image: google/cadvisor:latest
     container_name: cadvisor
@@ -41,6 +55,20 @@ services:
       - /dev/disk/:/dev/disk:ro
     ports:
       - 18080:8080
+    restart: always
+    networks:
+      - promnet
+    user: root
+
+  blackbox_exporter:
+    image: prom/blackbox-exporter
+    container_name: blackbox_exporter
+    volumes:
+      - ./blackbox.yml:/config/blackbox.yml
+    command:
+      - "--config.file=/config/blackbox.yml"
+    ports:
+      - 9115:9115
     restart: always
     networks:
       - promnet

--- a/packages/backend/monitoring/prometheus.yml
+++ b/packages/backend/monitoring/prometheus.yml
@@ -25,7 +25,7 @@ scrape_configs:
   - job_name: 'blackbox'
     metrics_path: /probe
     params:
-      module: [http_2xx]  # Blackbox Exporter의 http_2xx 모듈 사용
+      module: [http_2xx]
     static_configs:
       - targets:
         - '(your targets)'

--- a/packages/backend/monitoring/prometheus.yml
+++ b/packages/backend/monitoring/prometheus.yml
@@ -1,0 +1,63 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+scrape_configs:
+  - job_name: 'git-challenge server node'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['(your node)']
+
+  - job_name: 'git-challenge server cAdvisor'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['(your cAdvisor)']
+
+  - job_name: 'container server node'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['(your node)']
+
+  - job_name: 'container server cAdvisor'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['(your cAdvisor)']
+
+  - job_name: 'blackbox'
+    metrics_path: /probe
+    params:
+      module: [http_2xx]  # Blackbox Exporter의 http_2xx 모듈 사용
+    static_configs:
+      - targets:
+        - '(your targets)'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox_exporter:9115
+      - source_labels: [__param_target]
+        regex: ".*:3000/.*"
+        target_label: service
+        replacement: "frontend"
+      - source_labels: [__param_target]
+        regex: ".*:8080/.*"
+        target_label: service
+        replacement: "backend_8080"
+      - source_labels: [__param_target]
+        regex: ".*:8081/.*"
+        target_label: service
+        replacement: "backend_8081"
+      - source_labels: [__param_target]
+        regex: ".*git-challenge.com.*"
+        target_label: service
+        replacement: "git_challenge"
+
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - 'alertmanager:9093'
+
+rule_files:
+  - /prometheus/alert.rules.yml


### PR DESCRIPTION
close #309 

## ✅ 작업 내용

- 메인 서버에서 컨테이너 서버로 모니터링 스택 이전
- alertmanager 추가 배포
- blackbox exporter 추가 배포
- 알람 템플릿 작성
- 알람 슬랙 연동
- 알람 규칙 작성 및 테스트

알람 규칙 설명은 [개발 위키](https://bow-snail-89d.notion.site/c2bf3eb1bb1949a292a96bf81147c692?pvs=4)에 적어 둡니다~

## 📸 스크린샷

이런 느낌으로 알람이 와요 (우리 #monitoring 채널 가입하시면 알람 받을 수 있어요)
<img width="730" alt="image" src="https://github.com/boostcampwm2023/web01-GitChallenge/assets/50614833/99fce81b-aa54-46b8-a6a8-8b760f86275d">

## 📌 이슈 사항

- yml 파일들은 아카이빙 느낌으로 레포지토리에 옮겼습니다. 실제 모니터링에 사용되는 시크릿들(slack hook api, 서버 IP/Port)은 그냥 your~~~로 마스킹했어요

## 🟢 완료 조건

- 서버 장애 발생 시 webhook 통해 slack 알람 받을 수 있음

## ✍ 궁금한 점

- 없습니다!