### PR TITLE
[FE] feat#13 문제 상태 전체 초기화 구현

### DIFF
--- a/packages/frontend/src/apis/quiz.ts
+++ b/packages/frontend/src/apis/quiz.ts
@@ -33,8 +33,7 @@ export const quizAPI = {
     return data;
   },
   resetQuizById: async (id: number) => {
-    const { data } = await instance.delete(`${API_PATH.QUIZZES}/${id}/command`);
-    return data;
+    await instance.delete(`${API_PATH.QUIZZES}/${id}/command`);
   },
   getSharedAnswer: async (slug: string) => {
     const { data } = await instance.get<GetSharedAnswerResponse>(

--- a/packages/frontend/src/apis/session.ts
+++ b/packages/frontend/src/apis/session.ts
@@ -4,6 +4,10 @@ import { UserQuizStatus } from "../types/user";
 import { instance } from "./base";
 
 export const sessionAPI = {
+  resetSession: async () => {
+    const { data } = await instance.delete(API_PATH.SESSION);
+    return data;
+  },
   getUserQuizStatus: async () => {
     const { data } = await instance.get<UserQuizStatus>(
       `${API_PATH.SESSION}/solved`,

--- a/packages/frontend/src/apis/session.ts
+++ b/packages/frontend/src/apis/session.ts
@@ -5,8 +5,7 @@ import { instance } from "./base";
 
 export const sessionAPI = {
   resetSession: async () => {
-    const { data } = await instance.delete(API_PATH.SESSION);
-    return data;
+    await instance.delete(API_PATH.SESSION);
   },
   getUserQuizStatus: async () => {
     const { data } = await instance.get<UserQuizStatus>(

--- a/packages/frontend/src/design-system/components/common/SideBar/GitHelpAccordion.tsx
+++ b/packages/frontend/src/design-system/components/common/SideBar/GitHelpAccordion.tsx
@@ -7,7 +7,7 @@ import { Accordion } from "../Accordion";
 import { gitHelpNavigation } from "./nav";
 import * as styles from "./SideBar.css";
 
-export default function GitHelpAccordian() {
+export default function GitHelpAccordion() {
   const { pathname } = useRouter();
   const current = pathname === BROWSWER_PATH.MAIN;
   return (

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
@@ -1,8 +1,13 @@
-import { style } from "@vanilla-extract/css";
+import { globalStyle, style } from "@vanilla-extract/css";
 
 import color from "../../../tokens/color";
 import typography from "../../../tokens/typography";
-import { border, flexAlignCenter, flexColumn } from "../../../tokens/utils.css";
+import {
+  border,
+  flexAlignCenter,
+  flexColumn,
+  scrollBarHidden,
+} from "../../../tokens/utils.css";
 
 export const linkContainerStyle = style([
   flexColumn,
@@ -51,4 +56,36 @@ export const linkStyle = style([
 
 export const checkIcon = style({
   color: color.$semantic.success,
+});
+
+export const navigation = style([
+  flexColumn,
+  scrollBarHidden,
+  {
+    maxHeight: "80vh",
+    gap: 24,
+  },
+]);
+
+export const resetButton = style([
+  typography.$semantic.caption1Regular,
+  {
+    width: 200,
+    backgroundColor: "transparent",
+    color: color.$scale.grey800,
+    border: "none",
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    borderTop: `1px solid ${color.$scale.grey300}`,
+    paddingTop: 10,
+    paddingLeft: 20,
+    gap: 5,
+  },
+]);
+
+globalStyle(`${resetButton} > svg`, {
+  position: "absolute",
+  left: 0,
+  top: 12.5,
 });

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.css.ts
@@ -68,6 +68,7 @@ export const navigation = style([
 ]);
 
 export const resetButton = style([
+  flexAlignCenter,
   typography.$semantic.caption1Regular,
   {
     width: 200,
@@ -75,8 +76,6 @@ export const resetButton = style([
     color: color.$scale.grey800,
     border: "none",
     position: "relative",
-    display: "flex",
-    alignItems: "center",
     borderTop: `1px solid ${color.$scale.grey300}`,
     paddingTop: 10,
     paddingLeft: 20,

--- a/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
+++ b/packages/frontend/src/design-system/components/common/SideBar/SideBar.tsx
@@ -1,29 +1,64 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { GrPowerReset } from "react-icons/gr";
 import { IoMdCheckmark } from "react-icons/io";
 
+import { sessionAPI } from "../../../../apis/session";
 import { BROWSWER_PATH } from "../../../../constants/path";
-import { useUserQuizStatus } from "../../../../contexts/UserQuizStatusContext";
+import {
+  UserQuizStatusActionType,
+  useUserQuizStatus,
+  useUserQuizStatusDispatch,
+} from "../../../../contexts/UserQuizStatusContext";
 import * as layout from "../../../tokens/layout.css";
 import { Accordion } from "../Accordion";
+import { toast } from "../Toast";
 
-import GitHelpAccordian from "./GitHelpAccordian";
+import GitHelpAccordion from "./GitHelpAccordion";
 import { sidebarNavigation } from "./nav";
 import * as styles from "./SideBar.css";
 
 export default function SideBar() {
+  const userQuizStatusDispatcher = useUserQuizStatusDispatch();
+
+  const handleResetSession = async () => {
+    try {
+      await sessionAPI.resetSession();
+      userQuizStatusDispatcher({
+        type: UserQuizStatusActionType.Reset,
+      });
+      toast.success("문제가 성공적으로 초기화되었습니다!");
+    } catch (error) {
+      toast.error(
+        "문제 초기화 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+      );
+    }
+  };
+
   return (
-    <nav className={layout.sideBar}>
-      <GitHelpAccordian />
-      {sidebarNavigation.map((item) => (
-        <Accordion key={item.title} open>
-          <Accordion.Details>
-            <Accordion.Summary>{item.title}</Accordion.Summary>
-            <SubTitleList subItems={item.subItems} />
-          </Accordion.Details>
-        </Accordion>
-      ))}
-    </nav>
+    <div className={layout.sideBar}>
+      <nav className={styles.navigation}>
+        <GitHelpAccordion />
+        {sidebarNavigation.map((item) => (
+          <Accordion key={item.title} open>
+            <Accordion.Details>
+              <Accordion.Summary>{item.title}</Accordion.Summary>
+              <SubTitleList subItems={item.subItems} />
+            </Accordion.Details>
+          </Accordion>
+        ))}
+      </nav>
+      <div>
+        <button
+          type="button"
+          className={styles.resetButton}
+          onClick={handleResetSession}
+        >
+          <GrPowerReset />
+          문제 상태 전체 초기화하기
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/packages/frontend/src/design-system/tokens/layout.css.ts
+++ b/packages/frontend/src/design-system/tokens/layout.css.ts
@@ -1,13 +1,6 @@
 import { style } from "@vanilla-extract/css";
 
-import {
-  flex,
-  flexColumn,
-  scrollBarHidden,
-  topLayer,
-  widthFull,
-  widthMax,
-} from "./utils.css";
+import { flex, flexColumn, topLayer, widthFull, widthMax } from "./utils.css";
 
 export const headerHeight = "56px";
 const footerHeight = "250px";
@@ -35,12 +28,11 @@ export const base = style([
 
 export const sideBar = style([
   flexColumn,
-  scrollBarHidden,
   {
     maxHeight: "100vh",
     width: 250,
     padding: "30px 0px",
-    gap: 24,
+    gap: 20,
   },
 ]);
 


### PR DESCRIPTION
close #13 

## ✅ 작업 내용
- 사이드바 하단 버튼으로 문제 상태 전체 초기화 구현

## 📸 스크린샷(FE만)
![Jan-18-2024 16-59-03](https://github.com/boostcampwm2023/web01-GitChallenge/assets/79246447/ec0ddf58-5f48-4024-94c3-fceaee5abcbe)

## 📌 이슈 사항
없습니다!

## 🟢 완료 조건
- 문제 상태 전체 초기화 버튼을 누르면 세션이 지워짐
- 사이드바 상태가 초기값으로 변경됨

## ✍ 궁금한 점
없습니다!